### PR TITLE
Test mixing of contentless and contentful components

### DIFF
--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -38,6 +38,24 @@ def test_render_content(catalog, folder):
 </section>""".strip()
 
 
+@pytest.mark.parametrize(
+    "source, expected",
+    [
+        ("<Title>Hi</Title><Title>Hi</Title>", '<h1>Hi</h1><h1>Hi</h1>'),
+        ("<Icon /><Icon />", '<i class="icon"></i><i class="icon"></i>'),
+        ("<Title>Hi</Title><Icon />", '<h1>Hi</h1><i class="icon"></i>'),
+        ("<Icon /><Title>Hi</Title>", '<i class="icon"></i><h1>Hi</h1>'),
+    ],
+)
+def test_render_mix_of_contentful_and_contentless_components(catalog, folder, source, expected):
+    (folder / "Icon.jinja").write_text('<i class="icon"></i>')
+    (folder / "Title.jinja").write_text("<h1>{{ content }}</h1>")
+    (folder / "Page.jinja").write_text(source)
+
+    html = catalog.render("Page")
+    assert html == expected
+
+
 def test_composition(catalog, folder):
     (folder / "Greeting.jinja").write_text("""
 {#def message #}


### PR DESCRIPTION
This is basically a bug report in the form of a PR with a failing test.

The new test case shows that all combinations of contentless and contentful components works as expected, except when using a contentless component before a contentful component, e.g.:

```
<Icon />
<Title>Hi</Title>
```

This fails with:

```
=================================================== FAILURES ===================================================
_ test_render_mix_of_contentful_and_contentless_components[<Icon /><Title>Hi</Title>-<i class="icon"></i><h1>Hi</h1>] _

catalog = <jinjax.catalog.Catalog object at 0x7f68a8d1a3a0>
folder = PosixPath('/tmp/pytest-of-jodal/pytest-26/test_render_mix_of_contentful_3/components')
source = '<Icon /><Title>Hi</Title>', expected = '<i class="icon"></i><h1>Hi</h1>'

    @pytest.mark.parametrize(
        "source, expected",
        [
            ("<Title>Hi</Title><Title>Hi</Title>", '<h1>Hi</h1><h1>Hi</h1>'),
            ("<Icon /><Icon />", '<i class="icon"></i><i class="icon"></i>'),
            ("<Title>Hi</Title><Icon />", '<h1>Hi</h1><i class="icon"></i>'),
            ("<Icon /><Title>Hi</Title>", '<i class="icon"></i><h1>Hi</h1>'),
        ],
    )
    def test_render_mix_of_contentful_and_contentless_components(catalog, folder, source, expected):
        (folder / "Icon.jinja").write_text('<i class="icon"></i>')
        (folder / "Title.jinja").write_text("<h1>{{ content }}</h1>")
        (folder / "Page.jinja").write_text(source)
    
>       html = catalog.render("Page")

tests/test_render.py:55: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
src/jinjax/catalog.py:123: in render
    tmpl = self.jinja_env.get_template(tmpl_name)
.venv/lib/python3.9/site-packages/jinja2/environment.py:1010: in get_template
    return self._load_template(name, globals)
.venv/lib/python3.9/site-packages/jinja2/environment.py:969: in _load_template
    template = self.loader.load(self, name, self.make_globals(globals))
.venv/lib/python3.9/site-packages/jinja2/loaders.py:138: in load
    code = environment.compile(source, name, filename)
.venv/lib/python3.9/site-packages/jinja2/environment.py:768: in compile
    self.handle_exception(source=source_hint)
.venv/lib/python3.9/site-packages/jinja2/environment.py:936: in handle_exception
    raise rewrite_traceback_stack(source=source)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

>   ???
E   jinja2.exceptions.TemplateSyntaxError: Unclosed component <Title>

/tmp/pytest-of-jodal/pytest-26/test_render_mix_of_contentful_3/components/Page.jinja:2: TemplateSyntaxError
```