### PR TITLE
Lazily cast additional HTML attributes to string

### DIFF
--- a/src/jinjax/html_attrs.py
+++ b/src/jinjax/html_attrs.py
@@ -1,7 +1,6 @@
 import re
 from typing import Any
 
-
 CLASS_KEY = "class"
 CLASS_ALT_KEY = "classes"
 CLASS_KEYS = (CLASS_KEY, CLASS_ALT_KEY)
@@ -22,6 +21,21 @@ def quote(text: str) -> str:
     return f'"{text}"'
 
 
+class LazyString:
+    """The string representation of an object, but lazily casted to str."""
+
+    def __init__(self, value: Any) -> None:
+        self.value = value
+
+    def __str__(self) -> str:
+        if not hasattr(self, "_value_str"):
+            self._value_str = str(self.value)
+        return self._value_str
+
+    def __eq__(self, other: Any) -> bool:
+        return str(self) == other
+
+
 class HTMLAttrs:
     def __init__(self, attrs) -> None:
         attributes: "dict[str, str]" = {}
@@ -38,7 +52,7 @@ class HTMLAttrs:
             if value is True:
                 properties.add(name)
             elif value not in (False, None):
-                attributes[name] = str(value)
+                attributes[name] = LazyString(value)
 
         self.__attributes = attributes
         self.__properties = properties

--- a/tests/test_html_attrs.py
+++ b/tests/test_html_attrs.py
@@ -1,3 +1,4 @@
+import pytest
 from jinjax.html_attrs import HTMLAttrs
 
 
@@ -154,3 +155,16 @@ def test_do_escape_quotes_inside_attrs():
     result = attrs.render()
     print(result)
     assert expected == result
+
+
+def test_additional_attributes_are_lazily_evaluated_to_strings():
+    class TestObject:
+        def __str__(self):
+            raise RuntimeError("Should not be called unless rendered.")
+
+    attrs = HTMLAttrs({
+        "some_object": TestObject(),
+    })
+
+    with pytest.raises(RuntimeError):
+        attrs.render()


### PR DESCRIPTION
Hello, @jpsca 👋 Thanks a lot for building JinjaX, it's a great tool!

We are currently building a Django-based project with JinjaX at the core. Most of our class-based views end up delegating to `jinjax.Catalog.render()` in one way or another, passing on any context built up by Django's view-hierarchy to `.render()`. The _problem_ with this is that we have observed some relatively large performance regressions related to `jinjax.html_attrs.HTMLAttrs.__init__()` casting any additional HTML attributes to `str` even though `{{ attrs.render() }}` is never invoked in our top-level components. The most common occurrence of this problem is when Django query sets are inserted into the template context and JinjaX ends up evaluating the entire query set when constructing `HTMLAttrs` even though the attributes are never rendered in the component template.

As a solution, if you wish to accept it, I propose that additional string values passed into components as `attrs` are not cast to `str` until the string representation is actually needed, for example when `attrs.render()` is invoked. This PR implements such a solution, by wrapping additional values in a custom-made `LazyString` object, which casts the passed value to `str` when `LazyString.__str__` is invoked.

Thanks in advance, let me know if you require any changes to the implementation or a more detailed description of the motivation behind this PR in order to consider the change!
- Jakob
