### PR TITLE
Reduce log level from info to debug

### DIFF
--- a/docs/docs.py
+++ b/docs/docs.py
@@ -5,7 +5,7 @@ import jinjax_ui
 from claydocs import Docs
 
 
-logging.getLogger("jinjax").setLevel(logging.INFO)
+logging.getLogger("jinjax").setLevel(logging.DEBUG)
 logging.getLogger("jinjax").addHandler(logging.StreamHandler())
 
 pages = [

--- a/src/jinjax/catalog.py
+++ b/src/jinjax/catalog.py
@@ -97,10 +97,10 @@ class Catalog:
             loader = self.prefixes[prefix]
             if root_path in loader.searchpath:
                 return
-            logger.info(f"Adding folder `{root_path}` with the prefix `{prefix}`")
+            logger.debug(f"Adding folder `{root_path}` with the prefix `{prefix}`")
             loader.searchpath.append(root_path)
         else:
-            logger.info(f"Adding folder `{root_path}` with the prefix `{prefix}`")
+            logger.debug(f"Adding folder `{root_path}` with the prefix `{prefix}`")
             self.prefixes[prefix] = jinja2.FileSystemLoader(root_path)
 
     def add_module(self, module: t.Any, *, prefix: str = "") -> None:
@@ -167,7 +167,7 @@ class Catalog:
         allowed_ext: "t.Iterable[str] | None" = ALLOWED_EXTENSIONS,
         **kwargs,
     ) -> "ComponentsMiddleware":
-        logger.info("Creating middleware")
+        logger.debug("Creating middleware")
         middleware = ComponentsMiddleware(
             application=application,
             allowed_ext=tuple(allowed_ext or []),


### PR DESCRIPTION
...to avoid polluting the logs of apps using JinjaX.

With JinjaX 0.25, logging from JinjaX started showing up whenever
we ran any command related to our Django project, including `python manage.py
shell`.

It is of course possible to get rid of this using our own log setup, but I
believe the correct solution is for JinjaX to keep all non-critical logging on
the debug level.
