### PR TITLE
Update css_and_js.mdx

### DIFF
--- a/docs/content/guide/css_and_js.mdx
+++ b/docs/content/guide/css_and_js.mdx
@@ -51,7 +51,7 @@ catalog.collected_css
 
 You can add the `<link>` and `<script>` tags in your page automatically by calling `catalog.render_assets()` like this:
 
-```html+jinja title="components/Layout.jinja" hl_lines="7"
+```html+jinja title="components/Layout.jinja" hl_lines="8"
 {#def title #}
 
 <!DOCTYPE html>
@@ -104,7 +104,7 @@ app.wsgi_app = catalog.get_middleware(
 The middleware uses the battle-tested [Whitenoise library](http://whitenoise.evans.io/) and it will only respond to the *.css* and *.js* files inside the component(s) folder(s). You can configure it to also return files with other extensions. For example:
 
 ```python
-catalog.get_middleware(app, allowed_ext=[".css", ".js", ".svg", ".png"]
+catalog.get_middleware(app, allowed_ext=[".css", ".js", ".svg", ".png"])
 ```
 
 Be aware that, if you use this option, `get_middleware()` must be called **after** all folders are added.


### PR DESCRIPTION
catalog_render() highlight should be on 8
catalog.get_middleware( ')' missing parenthesis added