### PR TITLE
Allow to declare global (shared) css/js urls

### DIFF
--- a/docs/content/guide/css_and_js.mdx
+++ b/docs/content/guide/css_and_js.mdx
@@ -11,15 +11,49 @@ Your components might need custom styles or custom JavaScript for many reasons. 
 
 The css and/or the js of a component must be declared in the metatada header with `{#css ... #}` and `{#js ... #}`
 
-```html+jinja
+```html
 {#css lorem.css, ipsum.css #}
 {#js foo.js, bar.js #}
 ```
 
 - The filepaths must be relative to the root of your components catalog (e.g.: `components/`).
 - Multiple assets must be separated by commas.
-- Only **one** {#css ... #} and **one** {#js ... #} tag is allowed per component,
+- Only **one** {#css ... #} and **one** {#js ... #} tag is allowed per component at most,
   but both are optional.
+
+
+### Global assets
+
+Best practice is to store both CSS and JS files of the component within the same folder.
+Doing that has several advantages, including easier component reuse in other
+projects, improved code readability, and simplified debugging.
+
+However, there are instances when you may need to rely on global CSS or JS files,
+such as third-party libraries. In such cases, you can specify these dependencies
+in the component's metadata using URLs that start with either
+"/", "http://," or "https://."
+
+When you do this, JinjaX will render them as is; instead of prepending them
+with the component's prefix like it normally does.
+
+For example, this code:
+
+```html+jinja
+{#css foo.css, bar.css, /static/bootstrap.min.css #}
+{#js http://example.com/cdn/moment.js, bar.js  #}
+
+{{ catalog.render_assets() }}
+```
+
+will be render as this HTML output:
+
+```html
+<link rel="stylesheet" href="/static/components/foo.css">
+<link rel="stylesheet" href="/static/components/bar.css">
+<link rel="stylesheet" href="/static/bootstrap.min.css">
+<script type="module" src="http://example.com/cdn/moment.js"></script>
+<script type="module" src="/static/components/bar.js"></script>
+```
 
 
 ## Including assets in your pages

--- a/docs/static/docs.css
+++ b/docs/static/docs.css
@@ -1,1 +1,3631 @@
-/*! tailwindcss v3.2.4 | MIT License | https://tailwindcss.com*/*,:after,:before{box-sizing:border-box;border:0 solid #e5e7eb}:after,:before{--tw-content:""}html{line-height:1.5;-webkit-text-size-adjust:100%;-moz-tab-size:4;-o-tab-size:4;tab-size:4;font-family:silka,sans-serif;font-feature-settings:normal}body{margin:0;line-height:inherit}hr{height:0;color:inherit;border-top-width:1px}abbr:where([title]){-webkit-text-decoration:underline dotted;text-decoration:underline dotted}h1,h2,h3,h4,h5,h6{font-size:inherit;font-weight:inherit}a{color:inherit;text-decoration:inherit}b,strong{font-weight:bolder}code,kbd,pre,samp{font-family:ui-monospace,SFMono-Regular,Menlo,Monaco,Consolas,Liberation Mono,Courier New,monospace;font-size:1em}small{font-size:80%}sub,sup{font-size:75%;line-height:0;position:relative;vertical-align:initial}sub{bottom:-.25em}sup{top:-.5em}table{text-indent:0;border-color:inherit;border-collapse:collapse}button,input,optgroup,select,textarea{font-family:inherit;font-size:100%;font-weight:inherit;line-height:inherit;color:inherit;margin:0;padding:0}button,select{text-transform:none}[type=button],[type=reset],[type=submit],button{-webkit-appearance:button;background-color:initial;background-image:none}:-moz-focusring{outline:auto}:-moz-ui-invalid{box-shadow:none}progress{vertical-align:initial}::-webkit-inner-spin-button,::-webkit-outer-spin-button{height:auto}[type=search]{-webkit-appearance:textfield;outline-offset:-2px}::-webkit-search-decoration{-webkit-appearance:none}::-webkit-file-upload-button{-webkit-appearance:button;font:inherit}summary{display:list-item}blockquote,dd,dl,figure,h1,h2,h3,h4,h5,h6,hr,p,pre{margin:0}fieldset{margin:0}fieldset,legend{padding:0}menu,ol,ul{list-style:none;margin:0;padding:0}textarea{resize:vertical}input::-moz-placeholder,textarea::-moz-placeholder{opacity:1;color:#9ca3af}input::placeholder,textarea::placeholder{opacity:1;color:#9ca3af}[role=button],button{cursor:pointer}:disabled{cursor:default}audio,canvas,embed,iframe,img,object,svg,video{display:block;vertical-align:middle}img,video{max-width:100%;height:auto}[hidden]{display:none}@font-face{font-family:silka;src:url(silka.woff2) format("woff2");font-display:swap;font-style:normal;font-weight:300}@font-face{font-family:silka;src:url(silka-medium.woff2) format("woff2");font-display:swap;font-style:normal;font-weight:400}@font-face{font-family:silka;src:url(silka-semibold.woff2) format("woff2");font-display:swap;font-style:normal;font-weight:600}:root{--ease-3:cubic-bezier(0.25,0,0.3,1);--ease-out-5:cubic-bezier(0,0,0,1);--ease-elastic-3:cubic-bezier(0.5,1.25,0.75,1.25);--ease-elastic-4:cubic-bezier(0.5,1.5,0.75,1.25)}*,::backdrop,:after,:before{--tw-border-spacing-x:0;--tw-border-spacing-y:0;--tw-translate-x:0;--tw-translate-y:0;--tw-rotate:0;--tw-skew-x:0;--tw-skew-y:0;--tw-scale-x:1;--tw-scale-y:1;--tw-pan-x: ;--tw-pan-y: ;--tw-pinch-zoom: ;--tw-scroll-snap-strictness:proximity;--tw-ordinal: ;--tw-slashed-zero: ;--tw-numeric-figure: ;--tw-numeric-spacing: ;--tw-numeric-fraction: ;--tw-ring-inset: ;--tw-ring-offset-width:0px;--tw-ring-offset-color:#fff;--tw-ring-color:#3b82f680;--tw-ring-offset-shadow:0 0 #0000;--tw-ring-shadow:0 0 #0000;--tw-shadow:0 0 #0000;--tw-shadow-colored:0 0 #0000;--tw-blur: ;--tw-brightness: ;--tw-contrast: ;--tw-grayscale: ;--tw-hue-rotate: ;--tw-invert: ;--tw-saturate: ;--tw-sepia: ;--tw-drop-shadow: ;--tw-backdrop-blur: ;--tw-backdrop-brightness: ;--tw-backdrop-contrast: ;--tw-backdrop-grayscale: ;--tw-backdrop-hue-rotate: ;--tw-backdrop-invert: ;--tw-backdrop-opacity: ;--tw-backdrop-saturate: ;--tw-backdrop-sepia: }.pointer-events-none{pointer-events:none}.fixed{position:fixed}.absolute{position:absolute}.relative{position:relative}.sticky{position:sticky}.inset-0{top:0;right:0;bottom:0;left:0}.left-0{left:0}.top-0{top:0}.bottom-0{bottom:0}.right-0{right:0}.top-full{top:100%}.-left-1\/2{left:-50%}.left-1\/2{left:50%}.z-50{z-index:50}.z-10{z-index:10}.z-0{z-index:0}.z-30{z-index:30}.float-right{float:right}.float-left{float:left}.m-0{margin:0}.m-2{margin:.5rem}.mx-auto{margin-left:auto;margin-right:auto}.my-6{margin-top:1.5rem;margin-bottom:1.5rem}.-mx-4{margin-left:-1rem;margin-right:-1rem}.mx-\[0\.1rem\]{margin-left:.1rem;margin-right:.1rem}.mr-auto{margin-right:auto}.ml-2{margin-left:.5rem}.ml-3{margin-left:.75rem}.mb-8{margin-bottom:2rem}.mb-6{margin-bottom:1.5rem}.mr-6{margin-right:1.5rem}.mb-2{margin-bottom:.5rem}.mt-6{margin-top:1.5rem}.mt-10{margin-top:2.5rem}.mb-5{margin-bottom:1.25rem}.mb-3{margin-bottom:.75rem}.ml-auto{margin-left:auto}.mt-16{margin-top:4rem}.mr-5{margin-right:1.25rem}.ml-4{margin-left:1rem}.mr-4{margin-right:1rem}.ml-0{margin-left:0}.mb-4{margin-bottom:1rem}.mb-10{margin-bottom:2.5rem}.-mt-1{margin-top:-.25rem}.-ml-1{margin-left:-.25rem}.mt-2{margin-top:.5rem}.mb-1{margin-bottom:.25rem}.mt-1{margin-top:.25rem}.ml-8{margin-left:2rem}.block{display:block}.inline-block{display:inline-block}.flex{display:flex}.grid{display:grid}.hidden{display:none}.h-14{height:3.5rem}.h-10{height:2.5rem}.h-8{height:2rem}.h-5{height:1.25rem}.h-6{height:1.5rem}.h-20{height:5rem}.h-36{height:9rem}.h-full{height:100%}.h-screen{height:100vh}.h-fit{height:-moz-fit-content;height:fit-content}.h-7{height:1.75rem}.h-12{height:3rem}.h-0{height:0}.h-4{height:1rem}.max-h-\[32px\]{max-height:32px}.max-h-96{max-height:24rem}.min-h-screen{min-height:100vh}.w-full{width:100%}.w-8{width:2rem}.w-5{width:1.25rem}.w-14{width:3.5rem}.w-20{width:5rem}.w-10{width:2.5rem}.w-72{width:18rem}.w-1\/2{width:50%}.w-4{width:1rem}.w-64{width:16rem}.w-7{width:1.75rem}.w-0{width:0}.w-6{width:1.5rem}.max-w-\[100rem\]{max-width:100rem}.max-w-full{max-width:100%}.max-w-4xl{max-width:56rem}.max-w-6xl{max-width:72rem}.max-w-md{max-width:28rem}.max-w-5xl{max-width:64rem}.max-w-screen-sm{max-width:640px}.max-w-\[40rem\]{max-width:40rem}.flex-grow{flex-grow:1}.origin-center{transform-origin:center}.rotate-180{--tw-rotate:180deg}.rotate-180,.rotate-90{transform:translate(var(--tw-translate-x),var(--tw-translate-y)) rotate(var(--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y)) scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y))}.rotate-90{--tw-rotate:90deg}.scale-100{--tw-scale-x:1;--tw-scale-y:1;transform:translate(var(--tw-translate-x),var(--tw-translate-y)) rotate(var(--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y)) scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y))}.transform-gpu{transform:translate3d(var(--tw-translate-x),var(--tw-translate-y),0) rotate(var(--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y)) scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y))}.cursor-pointer{cursor:pointer}.touch-manipulation{touch-action:manipulation}.select-none{-webkit-user-select:none;-moz-user-select:none;user-select:none}.appearance-none{-webkit-appearance:none;-moz-appearance:none;appearance:none}.grid-cols-1{grid-template-columns:repeat(1,minmax(0,1fr))}.flex-col{flex-direction:column}.items-start{align-items:flex-start}.items-end{align-items:flex-end}.items-center{align-items:center}.justify-start{justify-content:flex-start}.justify-center{justify-content:center}.justify-evenly{justify-content:space-evenly}.gap-x-4{-moz-column-gap:1rem;column-gap:1rem}.gap-y-6{row-gap:1.5rem}.space-x-8>:not([hidden])~:not([hidden]){--tw-space-x-reverse:0;margin-right:calc(2rem*var(--tw-space-x-reverse));margin-left:calc(2rem*(1 - var(--tw-space-x-reverse)))}.space-x-1>:not([hidden])~:not([hidden]){--tw-space-x-reverse:0;margin-right:calc(.25rem*var(--tw-space-x-reverse));margin-left:calc(.25rem*(1 - var(--tw-space-x-reverse)))}.space-x-4>:not([hidden])~:not([hidden]){--tw-space-x-reverse:0;margin-right:calc(1rem*var(--tw-space-x-reverse));margin-left:calc(1rem*(1 - var(--tw-space-x-reverse)))}.overflow-hidden{overflow:hidden}.overflow-x-auto{overflow-x:auto}.overflow-y-auto{overflow-y:auto}.overflow-x-hidden{overflow-x:hidden}.overflow-y-hidden{overflow-y:hidden}.overscroll-contain{overscroll-behavior:contain}.scroll-smooth{scroll-behavior:smooth}.whitespace-nowrap{white-space:nowrap}.rounded{border-radius:.25rem}.rounded-2xl{border-radius:1rem}.rounded-md{border-radius:.375rem}.rounded-t{border-top-left-radius:.25rem;border-top-right-radius:.25rem}.rounded-b{border-bottom-right-radius:.25rem;border-bottom-left-radius:.25rem}.border{border-width:1px}.border-2{border-width:2px}.border-y{border-top-width:1px}.border-b,.border-y{border-bottom-width:1px}.border-l-2{border-left-width:2px}.border-t{border-top-width:1px}.border-r{border-right-width:1px}.border-l{border-left-width:1px}.border-r-0{border-right-width:0}.border-t-0{border-top-width:0}.border-l-4{border-left-width:4px}.border-r-4{border-right-width:4px}.border-b-8{border-bottom-width:8px}.border-zinc-200{--tw-border-opacity:1;border-color:rgb(228 228 231/var(--tw-border-opacity))}.border-neutral-300{--tw-border-opacity:1;border-color:rgb(212 212 212/var(--tw-border-opacity))}.border-stone-100{--tw-border-opacity:1;border-color:rgb(245 245 244/var(--tw-border-opacity))}.border-zinc-100{--tw-border-opacity:1;border-color:rgb(244 244 245/var(--tw-border-opacity))}.border-transparent{border-color:#0000}.border-zinc-600{--tw-border-opacity:1;border-color:rgb(82 82 91/var(--tw-border-opacity))}.border-orange-200{--tw-border-opacity:1;border-color:rgb(254 215 170/var(--tw-border-opacity))}.border-zinc-300{--tw-border-opacity:1;border-color:rgb(212 212 216/var(--tw-border-opacity))}.border-yellow-200{--tw-border-opacity:1;border-color:rgb(254 240 138/var(--tw-border-opacity))}.border-rose-200{--tw-border-opacity:1;border-color:rgb(254 205 211/var(--tw-border-opacity))}.border-stone-300{--tw-border-opacity:1;border-color:rgb(214 211 209/var(--tw-border-opacity))}.border-white{--tw-border-opacity:1;border-color:rgb(255 255 255/var(--tw-border-opacity))}.border-b-white{--tw-border-opacity:1;border-bottom-color:rgb(255 255 255/var(--tw-border-opacity))}.bg-white{--tw-bg-opacity:1;background-color:rgb(255 255 255/var(--tw-bg-opacity))}.bg-white\/60{background-color:#fff9}.bg-zinc-50{--tw-bg-opacity:1;background-color:rgb(250 250 250/var(--tw-bg-opacity))}.bg-stone-200{--tw-bg-opacity:1;background-color:rgb(231 229 228/var(--tw-bg-opacity))}.bg-stone-50{--tw-bg-opacity:1;background-color:rgb(250 250 249/var(--tw-bg-opacity))}.bg-black\/0{background-color:#0000}.bg-zinc-800{--tw-bg-opacity:1;background-color:rgb(39 39 42/var(--tw-bg-opacity))}.bg-orange-100{--tw-bg-opacity:1;background-color:rgb(255 237 213/var(--tw-bg-opacity))}.bg-zinc-100{--tw-bg-opacity:1;background-color:rgb(244 244 245/var(--tw-bg-opacity))}.bg-yellow-100{--tw-bg-opacity:1;background-color:rgb(254 249 195/var(--tw-bg-opacity))}.bg-rose-100{--tw-bg-opacity:1;background-color:rgb(255 228 230/var(--tw-bg-opacity))}.bg-opacity-90{--tw-bg-opacity:0.9}.bg-opacity-\[0\.001\]{--tw-bg-opacity:0.001}.bg-gradient-to-br{background-image:linear-gradient(to bottom right,var(--tw-gradient-stops))}.bg-gradient-to-b{background-image:linear-gradient(to bottom,var(--tw-gradient-stops))}.bg-gradient-to-tr{background-image:linear-gradient(to top right,var(--tw-gradient-stops))}.from-amber-400{--tw-gradient-from:#fbbf24;--tw-gradient-to:#fbbf2400;--tw-gradient-stops:var(--tw-gradient-from),var(--tw-gradient-to)}.from-emerald-400{--tw-gradient-from:#34d399;--tw-gradient-to:#34d39900;--tw-gradient-stops:var(--tw-gradient-from),var(--tw-gradient-to)}.from-stone-300{--tw-gradient-from:#d6d3d1;--tw-gradient-to:#d6d3d100;--tw-gradient-stops:var(--tw-gradient-from),var(--tw-gradient-to)}.from-lime-400{--tw-gradient-from:#a3e635;--tw-gradient-to:#a3e63500;--tw-gradient-stops:var(--tw-gradient-from),var(--tw-gradient-to)}.via-stone-200{--tw-gradient-to:#e7e5e400;--tw-gradient-stops:var(--tw-gradient-from),#e7e5e4,var(--tw-gradient-to)}.to-orange-400{--tw-gradient-to:#fb923c}.to-blue-500{--tw-gradient-to:#3b82f6}.to-stone-400{--tw-gradient-to:#a8a29e}.to-lime-600{--tw-gradient-to:#65a30d}.bg-clip-text{-webkit-background-clip:text;background-clip:text}.fill-zinc-700{fill:#3f3f46}.fill-zinc-600{fill:#52525b}.stroke-transparent{stroke:#0000}.stroke-zinc-700{stroke:#3f3f46}.stroke-2{stroke-width:2}.p-1{padding:.25rem}.p-\[0\.4rem\]{padding:.4rem}.p-0{padding:0}.p-4{padding:1rem}.p-2{padding:.5rem}.px-4{padding-left:1rem;padding-right:1rem}.px-6{padding-left:1.5rem;padding-right:1.5rem}.py-9{padding-top:2.25rem;padding-bottom:2.25rem}.py-6{padding-top:1.5rem;padding-bottom:1.5rem}.py-8{padding-top:2rem;padding-bottom:2rem}.py-4{padding-top:1rem;padding-bottom:1rem}.px-3{padding-left:.75rem;padding-right:.75rem}.py-24{padding-top:6rem;padding-bottom:6rem}.px-8{padding-left:2rem;padding-right:2rem}.py-3{padding-top:.75rem;padding-bottom:.75rem}.py-5{padding-top:1.25rem;padding-bottom:1.25rem}.py-1{padding-top:.25rem;padding-bottom:.25rem}.px-2{padding-left:.5rem;padding-right:.5rem}.px-5{padding-left:1.25rem;padding-right:1.25rem}.py-2{padding-top:.5rem;padding-bottom:.5rem}.py-7{padding-top:1.75rem;padding-bottom:1.75rem}.px-1{padding-left:.25rem;padding-right:.25rem}.py-\[0\.2rem\]{padding-top:.2rem;padding-bottom:.2rem}.pr-\[max\(0\.75rem\2c env\(safe-area-inset-right\)\)\]{padding-right:max(.75rem,env(safe-area-inset-right))}.pl-\[max\(0\.75rem\2c env\(safe-area-inset-left\)\)\]{padding-left:max(.75rem,env(safe-area-inset-left))}.pr-3{padding-right:.75rem}.pr-\[env\(safe-area-inset-right\)\]{padding-right:env(safe-area-inset-right)}.pl-\[env\(safe-area-inset-left\)\]{padding-left:env(safe-area-inset-left)}.pb-12{padding-bottom:3rem}.pb-3{padding-bottom:.75rem}.pl-\[max\(1rem\2c env\(safe-area-inset-left\)\)\]{padding-left:max(1rem,env(safe-area-inset-left))}.pr-\[max\(1rem\2c env\(safe-area-inset-right\)\)\]{padding-right:max(1rem,env(safe-area-inset-right))}.pl-2{padding-left:.5rem}.pb-16{padding-bottom:4rem}.pr-4{padding-right:1rem}.pb-14{padding-bottom:3.5rem}.pt-10{padding-top:2.5rem}.pl-8{padding-left:2rem}.pl-4{padding-left:1rem}.text-center{text-align:center}.font-sans{font-family:silka,sans-serif}.font-mono{font-family:ui-monospace,SFMono-Regular,Menlo,Monaco,Consolas,Liberation Mono,Courier New,monospace}.text-2xl{font-size:1.5rem;line-height:2rem}.text-sm{font-size:.875rem;line-height:1.25rem}.text-5xl{font-size:3rem;line-height:1}.text-4xl{font-size:2.25rem;line-height:2.5rem}.text-base{font-size:1rem;line-height:1.5rem}.text-3xl{font-size:1.875rem;line-height:2.25rem}.text-xl{font-size:1.25rem;line-height:1.75rem}.text-xs{font-size:.75rem;line-height:1rem}.text-lg{font-size:1.125rem;line-height:1.75rem}.font-bold{font-weight:700}.font-semibold{font-weight:600}.font-normal{font-weight:400}.font-black{font-weight:900}.font-extrabold{font-weight:800}.font-medium{font-weight:500}.uppercase{text-transform:uppercase}.leading-none{line-height:1}.leading-6{line-height:1.5rem}.leading-tight{line-height:1.25}.leading-relaxed{line-height:1.625}.tracking-tighter{letter-spacing:-.05em}.tracking-tight{letter-spacing:-.025em}.text-neutral-900{--tw-text-opacity:1;color:rgb(23 23 23/var(--tw-text-opacity))}.text-zinc-900{--tw-text-opacity:1;color:rgb(24 24 27/var(--tw-text-opacity))}.text-zinc-600{--tw-text-opacity:1;color:rgb(82 82 91/var(--tw-text-opacity))}.text-zinc-800{--tw-text-opacity:1;color:rgb(39 39 42/var(--tw-text-opacity))}.text-black{--tw-text-opacity:1;color:rgb(0 0 0/var(--tw-text-opacity))}.text-transparent{color:#0000}.text-zinc-700{--tw-text-opacity:1;color:rgb(63 63 70/var(--tw-text-opacity))}.text-zinc-500{--tw-text-opacity:1;color:rgb(113 113 122/var(--tw-text-opacity))}.text-orange-800{--tw-text-opacity:1;color:rgb(154 52 18/var(--tw-text-opacity))}.text-yellow-800{--tw-text-opacity:1;color:rgb(133 77 14/var(--tw-text-opacity))}.text-rose-900{--tw-text-opacity:1;color:rgb(136 19 55/var(--tw-text-opacity))}.text-rose-800{--tw-text-opacity:1;color:rgb(159 18 57/var(--tw-text-opacity))}.text-stone-900{--tw-text-opacity:1;color:rgb(28 25 23/var(--tw-text-opacity))}.text-zinc-400{--tw-text-opacity:1;color:rgb(161 161 170/var(--tw-text-opacity))}.underline{text-decoration-line:underline}.no-underline{text-decoration-line:none}.antialiased{-webkit-font-smoothing:antialiased;-moz-osx-font-smoothing:grayscale}.opacity-90{opacity:.9}.opacity-70{opacity:.7}.shadow-sm{--tw-shadow:0 1px 2px 0 #0000000d;--tw-shadow-colored:0 1px 2px 0 var(--tw-shadow-color)}.shadow,.shadow-sm{box-shadow:var(--tw-ring-offset-shadow,0 0 #0000),var(--tw-ring-shadow,0 0 #0000),var(--tw-shadow)}.shadow{--tw-shadow:0 1px 3px 0 #0000001a,0 1px 2px -1px #0000001a;--tw-shadow-colored:0 1px 3px 0 var(--tw-shadow-color),0 1px 2px -1px var(--tw-shadow-color)}.shadow-\[0_0_2px_0_\#000\]{--tw-shadow:0 0 2px 0 #000;--tw-shadow-colored:0 0 2px 0 var(--tw-shadow-color);box-shadow:var(--tw-ring-offset-shadow,0 0 #0000),var(--tw-ring-shadow,0 0 #0000),var(--tw-shadow)}.shadow-\[rgba\(0\2c 0\2c 0\2c 0\.2\)_0_-3px_6px\2c rgba\(0\2c 0\2c 0\2c 0\.2\)_0_3px_6px\]{--tw-shadow:#0003 0 -3px 6px,#0003 0 3px 6px;--tw-shadow-colored:0 -3px 6px var(--tw-shadow-color),0 3px 6px var(--tw-shadow-color);box-shadow:var(--tw-ring-offset-shadow,0 0 #0000),var(--tw-ring-shadow,0 0 #0000),var(--tw-shadow)}.shadow-black\/20{--tw-shadow-color:#0003;--tw-shadow:var(--tw-shadow-colored)}.drop-shadow-\[rgba\(0\2c 0\2c 0\2c 0\.2\)_0_-3px_1px\]{--tw-drop-shadow:drop-shadow(#0003 0 -3px 1px);filter:var(--tw-blur) var(--tw-brightness) var(--tw-contrast) var(--tw-grayscale) var(--tw-hue-rotate) var(--tw-invert) var(--tw-saturate) var(--tw-sepia) var(--tw-drop-shadow)}.backdrop-blur-sm{--tw-backdrop-blur:blur(4px)}.backdrop-blur-none,.backdrop-blur-sm{-webkit-backdrop-filter:var(--tw-backdrop-blur) var(--tw-backdrop-brightness) var(--tw-backdrop-contrast) var(--tw-backdrop-grayscale) var(--tw-backdrop-hue-rotate) var(--tw-backdrop-invert) var(--tw-backdrop-opacity) var(--tw-backdrop-saturate) var(--tw-backdrop-sepia);backdrop-filter:var(--tw-backdrop-blur) var(--tw-backdrop-brightness) var(--tw-backdrop-contrast) var(--tw-backdrop-grayscale) var(--tw-backdrop-hue-rotate) var(--tw-backdrop-invert) var(--tw-backdrop-opacity) var(--tw-backdrop-saturate) var(--tw-backdrop-sepia)}.backdrop-blur-none{--tw-backdrop-blur:blur(0)}.transition-all{transition-property:all;transition-timing-function:cubic-bezier(.4,0,.2,1);transition-duration:.15s}.transition-colors{transition-property:color,background-color,border-color,text-decoration-color,fill,stroke;transition-timing-function:cubic-bezier(.4,0,.2,1);transition-duration:.15s}.transition-transform{transition-property:transform;transition-timing-function:cubic-bezier(.4,0,.2,1);transition-duration:.15s}.duration-300{transition-duration:.3s}.fadeIn{opacity:0;transform:scale(1.2);animation:fadeInAnimation var(--ease-elastic-3) .3s;animation-iteration-count:1;animation-fill-mode:forwards}@keyframes fadeInAnimation{0%{opacity:0;transform:scale(2) rotate(10deg)}to{opacity:1;transform:scale(1.2) rotate(0)}}.prose{--tw-prose-body:#3f3f46;--tw-prose-headings:#18181b;--tw-prose-lead:#52525b;--tw-prose-links:#18181b;--tw-prose-bold:#18181b;--tw-prose-counters:#71717a;--tw-prose-bullets:#d4d4d8;--tw-prose-hr:#e4e4e7;--tw-prose-quotes:#18181b;--tw-prose-quote-borders:#e4e4e7;--tw-prose-captions:#71717a;--tw-prose-code:#18181b;--tw-prose-pre-code:#eee;--tw-prose-pre-border:#333;--tw-prose-pre-bg:#181818;--tw-prose-th-borders:#d4d4d8;--tw-prose-td-borders:#e4e4e7;--tw-prose-invert-body:#d4d4d8;--tw-prose-invert-headings:#fff;--tw-prose-invert-lead:#a1a1aa;--tw-prose-invert-links:#fff;--tw-prose-invert-bold:#fff;--tw-prose-invert-counters:#a1a1aa;--tw-prose-invert-bullets:#52525b;--tw-prose-invert-hr:#3f3f46;--tw-prose-invert-quotes:#f4f4f5;--tw-prose-invert-quote-borders:#3f3f46;--tw-prose-invert-captions:#a1a1aa;--tw-prose-invert-code:#fff;--tw-prose-invert-pre-code:#eee;--tw-prose-invert-pre-border:#333;--tw-prose-invert-pre-bg:#050505;--tw-prose-invert-th-borders:#52525b;--tw-prose-invert-td-borders:#3f3f46}.dark .prose{--tw-prose-body:var(--tw-prose-invert-body);--tw-prose-headings:var(--tw-prose-invert-headings);--tw-prose-lead:var(--tw-prose-invert-lead);--tw-prose-links:var(--tw-prose-invert-links);--tw-prose-bold:var(--tw-prose-invert-bold);--tw-prose-counters:var(--tw-prose-invert-counters);--tw-prose-bullets:var(--tw-prose-invert-bullets);--tw-prose-hr:var(--tw-prose-invert-hr);--tw-prose-quotes:var(--tw-prose-invert-quotes);--tw-prose-quote-borders:var(--tw-prose-invert-quote-borders);--tw-prose-captions:var(--tw-prose-invert-captions);--tw-prose-code:var(--tw-prose-invert-code);--tw-prose-pre-code:var(--tw-prose-invert-pre-code);--tw-prose-pre-border:var(--tw-prose-invert-pre-border);--tw-prose-pre-bg:var(--tw-prose-invert-pre-bg);--tw-prose-th-borders:var(--tw-prose-invert-th-borders);--tw-prose-td-borders:var(--tw-prose-invert-td-borders)}.prose{font-size:1rem;line-height:1.75;color:var(--tw-prose-body)}.prose :where(p):not(:where([class~=not-prose] *)){margin-top:1.25em;margin-bottom:1.25em}.prose :where([class~=lead]):not(:where([class~=not-prose] *)){color:var(--tw-prose-lead);font-size:1.25em;line-height:1.6;margin-top:1.2em;margin-bottom:1.2em}.prose :where(a):not(:where([class~=not-prose] *)){color:var(--tw-prose-links);text-decoration:underline;font-weight:500}a.headerlink{margin-left:.25rem;display:inline-block;text-decoration-line:none;opacity:0;transition-property:opacity;transition-timing-function:cubic-bezier(.4,0,.2,1);transition-duration:.15s}h2:hover a.headerlink,h3:hover a.headerlink,h4:hover a.headerlink,h5:hover a.headerlink,h6:hover a.headerlink{opacity:.5}.prose :where(strong):not(:where([class~=not-prose] *)){color:var(--tw-prose-bold);font-weight:600}.prose :where(a strong):not(:where([class~=not-prose] *)){color:inherit}.prose :where(blockquote strong):not(:where([class~=not-prose] *)){color:inherit}.prose :where(thead th strong):not(:where([class~=not-prose] *)){color:inherit}.prose :where(ol):not(:where([class~=not-prose] *)){list-style-type:decimal;margin-top:1.25em;margin-bottom:1.25em;padding-left:1.625em}.prose :where(ol[type=A]):not(:where([class~=not-prose] *)){list-style-type:upper-alpha}.prose :where(ol[type=a]):not(:where([class~=not-prose] *)){list-style-type:lower-alpha}.prose :where(ol[type=A s]):not(:where([class~=not-prose] *)){list-style-type:upper-alpha}.prose :where(ol[type=a s]):not(:where([class~=not-prose] *)){list-style-type:lower-alpha}.prose :where(ol[type=I]):not(:where([class~=not-prose] *)){list-style-type:upper-roman}.prose :where(ol[type=i]):not(:where([class~=not-prose] *)){list-style-type:lower-roman}.prose :where(ol[type=I s]):not(:where([class~=not-prose] *)){list-style-type:upper-roman}.prose :where(ol[type=i s]):not(:where([class~=not-prose] *)){list-style-type:lower-roman}.prose :where(ol[type="1"]):not(:where([class~=not-prose] *)){list-style-type:decimal}.prose :where(ul):not(:where([class~=not-prose] *)){list-style-type:disc;margin-top:1.25em;margin-bottom:1.25em;padding-left:1.625em}.prose :where(ol>li):not(:where([class~=not-prose] *))::marker{font-weight:400;color:var(--tw-prose-counters)}.prose :where(ul>li):not(:where([class~=not-prose] *))::marker{color:var(--tw-prose-bullets)}.prose :where(hr):not(:where([class~=not-prose] *)){border-color:var(--tw-prose-hr);border-top-width:1px;margin-top:3em;margin-bottom:3em}.prose :where(blockquote):not(:where([class~=not-prose] *)){font-weight:500;font-style:italic;color:var(--tw-prose-quotes);border-left-width:.25rem;border-left-color:var(--tw-prose-quote-borders);quotes:"\201C""\201D""\2018""\2019";margin-top:1.6em;margin-bottom:1.6em;padding-left:1em}.prose :where(blockquote p:first-of-type):not(:where([class~=not-prose] *)):before{content:open-quote}.prose :where(blockquote p:last-of-type):not(:where([class~=not-prose] *)):after{content:close-quote}.prose :where(h1):not(:where([class~=not-prose] *)){color:var(--tw-prose-headings);font-weight:800;font-size:2.25em;margin-top:0;margin-bottom:.8888889em;line-height:1.1111111}.prose :where(h1 strong):not(:where([class~=not-prose] *)){font-weight:900;color:inherit}.prose :where(h2):not(:where([class~=not-prose] *)){color:var(--tw-prose-headings);font-weight:700;font-size:1.5em;margin-top:2em;margin-bottom:1em;line-height:1.3333333}.prose :where(h2 strong):not(:where([class~=not-prose] *)){font-weight:800;color:inherit}.prose :where(h3):not(:where([class~=not-prose] *)){color:var(--tw-prose-headings);font-weight:600;font-size:1.25em;margin-top:1.6em;margin-bottom:.6em;line-height:1.6}.prose :where(h3 strong):not(:where([class~=not-prose] *)){font-weight:700;color:inherit}.prose :where(h4):not(:where([class~=not-prose] *)){color:var(--tw-prose-headings);font-weight:600;margin-top:1.5em;margin-bottom:.5em;line-height:1.5}.prose :where(h4 strong):not(:where([class~=not-prose] *)){font-weight:700;color:inherit}.prose :where(img):not(:where([class~=not-prose] *)){margin-top:2em;margin-bottom:2em}.prose :where(figure>*):not(:where([class~=not-prose] *)){margin-top:0;margin-bottom:0}.prose :where(figcaption):not(:where([class~=not-prose] *)){color:var(--tw-prose-captions);font-size:.875em;line-height:1.4285714;margin-top:.8571429em}.prose :where(code):not(:where([class~=not-prose] *)){color:var(--tw-prose-code);font-weight:600;font-size:.98em;white-space:nowrap;padding-left:4px;padding-right:4px}.prose :where(a code):not(:where([class~=not-prose] *)){color:inherit}.prose :where(h1 code):not(:where([class~=not-prose] *)){color:inherit}.prose :where(h2 code):not(:where([class~=not-prose] *)){color:inherit;font-size:.875em}.prose :where(h3 code):not(:where([class~=not-prose] *)){color:inherit;font-size:.9em}.prose :where(h4 code):not(:where([class~=not-prose] *)){color:inherit}.prose :where(blockquote code):not(:where([class~=not-prose] *)){color:inherit}.prose :where(thead th code):not(:where([class~=not-prose] *)){color:inherit}.prose :where(pre):not(:where([class~=not-prose] *)){color:var(--tw-prose-pre-code);background-color:var(--tw-prose-pre-bg);border:1px solid rgb(var(--tw-prose-pre-border));overflow-x:auto;font-weight:400;font-size:.98em;font-feature-settings:"kern";line-height:1.7142857;margin:0;border-radius:.375rem;padding:.8571429em 1.1428571em;white-space:pre;position:relative;z-index:30}@media (max-width:640px){.prose :where(pre):not(:where([class~=not-prose] *)){margin-left:-1rem;margin-right:-1rem;border-left:none;border-right:none;border-radius:0}}.prose :where(.filename):not(:where([class~=not-prose] *)){display:inline-block;padding:.4em 1em .8em;font-weight:500;font-size:.8rem;border-radius:.375rem .375rem 0 0;border:1px solid var(--tw-prose-hr);border-bottom:none;margin-bottom:-.375rem;font-family:monospace}.prose :where(pre a):not(:where([class~=not-prose] *)){text-decoration:none}.prose :where(pre code):not(:where([class~=not-prose] *)){background-color:initial;border-width:0;border-radius:0;padding:0;font-weight:inherit;color:inherit;font-size:inherit;font-family:inherit;line-height:inherit;overflow:auto;overscroll-behavior:contain;scrollbar-width:thin;white-space:pre}.prose :where(pre code::-webkit-scrollbar){width:2px;background-color:ButtonFace}.prose :where(table):not(:where([class~=not-prose] *)){width:100%;table-layout:auto;text-align:left;margin-top:2em;margin-bottom:2em;font-size:.875em;line-height:1.7142857}.prose :where(thead):not(:where([class~=not-prose] *)){border-bottom-width:1px;border-bottom-color:var(--tw-prose-th-borders)}.prose :where(thead th):not(:where([class~=not-prose] *)){color:var(--tw-prose-headings);font-weight:600;vertical-align:bottom;padding-right:.5714286em;padding-bottom:.5714286em;padding-left:.5714286em}.prose :where(tbody tr):not(:where([class~=not-prose] *)){border-bottom-width:1px;border-bottom-color:var(--tw-prose-td-borders)}.prose :where(tbody tr:last-child):not(:where([class~=not-prose] *)){border-bottom-width:0}.prose :where(tbody td):not(:where([class~=not-prose] *)){vertical-align:initial}.prose :where(tfoot):not(:where([class~=not-prose] *)){border-top-width:1px;border-top-color:var(--tw-prose-th-borders)}.prose :where(tfoot td):not(:where([class~=not-prose] *)){vertical-align:top}.prose :where(video):not(:where([class~=not-prose] *)){margin-top:2em;margin-bottom:2em}.prose :where(figure):not(:where([class~=not-prose] *)){margin-top:2em;margin-bottom:2em}.prose :where(li):not(:where([class~=not-prose] *)){margin-top:.5em;margin-bottom:.5em}.prose :where(ol>li):not(:where([class~=not-prose] *)){padding-left:.375em}.prose :where(ul>li):not(:where([class~=not-prose] *)){padding-left:.375em}.prose :where(.prose>ul>li p):not(:where([class~=not-prose] *)){margin-top:.75em;margin-bottom:.75em}.prose :where(.prose>ul>li>:first-child):not(:where([class~=not-prose] *)){margin-top:1.25em}.prose :where(.prose>ul>li>:last-child):not(:where([class~=not-prose] *)){margin-bottom:1.25em}.prose :where(.prose>ol>li>:first-child):not(:where([class~=not-prose] *)){margin-top:1.25em}.prose :where(.prose>ol>li>:last-child):not(:where([class~=not-prose] *)){margin-bottom:1.25em}.prose :where(ul ul,ul ol,ol ul,ol ol):not(:where([class~=not-prose] *)){margin-top:.75em;margin-bottom:.75em}.prose :where(hr+*):not(:where([class~=not-prose] *)){margin-top:0}.prose :where(h2+*):not(:where([class~=not-prose] *)){margin-top:0}.prose :where(h3+*):not(:where([class~=not-prose] *)){margin-top:0}.prose :where(h4+*):not(:where([class~=not-prose] *)){margin-top:0}.prose :where(thead th:first-child):not(:where([class~=not-prose] *)){padding-left:0}.prose :where(thead th:last-child):not(:where([class~=not-prose] *)){padding-right:0}.prose :where(tbody td,tfoot td):not(:where([class~=not-prose] *)){padding:.5714286em}.prose :where(tbody td:first-child,tfoot td:first-child):not(:where([class~=not-prose] *)){padding-left:0}.prose :where(tbody td:last-child,tfoot td:last-child):not(:where([class~=not-prose] *)){padding-right:0}.prose :where(.prose>:first-child):not(:where([class~=not-prose] *)){margin-top:0}.prose :where(.prose>:last-child):not(:where([class~=not-prose] *)){margin-bottom:0}.prose :where(.task-list .task-list):not(:where([class~=not-prose] *)){padding-left:1em}.prose :where(dl):not(:where([class~=not-prose] *)){margin-top:1.25em;margin-bottom:1.25em}.prose :where(dt):not(:where([class~=not-prose] *)){font-weight:700}.prose :where(dd):not(:where([class~=not-prose] *)){padding-left:1em}.prose pre code .hll{background-color:#49483e}.prose pre code .c{color:#75715e}.prose pre code .err{color:#960050;background-color:#1e0010}.prose pre code .k{color:#66d9ef}.prose pre code .l{color:#ae81ff}.prose pre code .n{color:#f8f8f2}.prose pre code .o{color:#f92672}.prose pre code .p{color:#f8f8f2}.prose pre code .c1,.prose pre code .ch,.prose pre code .cm,.prose pre code .cp,.prose pre code .cpf,.prose pre code .cs{color:#75715e}.prose pre code .gd{color:#f92672}.prose pre code .ge{font-style:italic}.prose pre code .gi{color:#a6e22e}.prose pre code .gs{font-weight:700}.prose pre code .gu{color:#75715e}.prose pre code .kc,.prose pre code .kd{color:#66d9ef}.prose pre code .kn{color:#f92672}.prose pre code .kp,.prose pre code .kr,.prose pre code .kt{color:#66d9ef}.prose pre code .ld{color:#e6db74}.prose pre code .m{color:#ae81ff}.prose pre code .s{color:#e6db74}.prose pre code .na{color:#a6e22e}.prose pre code .nb{color:#f8f8f2}.prose pre code .nc{color:#a6e22e}.prose pre code .no{color:#66d9ef}.prose pre code .nd{color:#a6e22e}.prose pre code .ni{color:#f8f8f2}.prose pre code .ne,.prose pre code .nf{color:#a6e22e}.prose pre code .nl,.prose pre code .nn{color:#f8f8f2}.prose pre code .nx{color:#a6e22e}.prose pre code .py{color:#f8f8f2}.prose pre code .nt{color:#f92672}.prose pre code .nv{color:#f8f8f2}.prose pre code .ow{color:#f92672}.prose pre code .w{color:#f8f8f2}.prose pre code .mb,.prose pre code .mf,.prose pre code .mh,.prose pre code .mi,.prose pre code .mo{color:#ae81ff}.prose pre code .dl,.prose pre code .s2,.prose pre code .sa,.prose pre code .sb,.prose pre code .sc,.prose pre code .sd{color:#e6db74}.prose pre code .se{color:#ae81ff}.prose pre code .s1,.prose pre code .sh,.prose pre code .si,.prose pre code .sr,.prose pre code .ss,.prose pre code .sx{color:#e6db74}.prose pre code .bp{color:#f8f8f2}.prose pre code .fm{color:#a6e22e}.prose pre code .vc,.prose pre code .vg,.prose pre code .vi,.prose pre code .vm{color:#f8f8f2}.prose pre code .il{color:#ae81ff}.last\:border-r:last-child{border-right-width:1px}.open\:block[open]{display:block}.hover\:border-zinc-300:hover{--tw-border-opacity:1;border-color:rgb(212 212 216/var(--tw-border-opacity))}.hover\:bg-zinc-100:hover{--tw-bg-opacity:1;background-color:rgb(244 244 245/var(--tw-bg-opacity))}.hover\:from-lime-400:hover{--tw-gradient-from:#a3e635;--tw-gradient-to:#a3e63500;--tw-gradient-stops:var(--tw-gradient-from),var(--tw-gradient-to)}.hover\:to-lime-400:hover{--tw-gradient-to:#a3e635}.hover\:text-zinc-900:hover{--tw-text-opacity:1;color:rgb(24 24 27/var(--tw-text-opacity))}.hover\:text-black:hover{--tw-text-opacity:1;color:rgb(0 0 0/var(--tw-text-opacity))}.hover\:opacity-100:hover{opacity:1}.hover\:shadow-sm:hover{--tw-shadow:0 1px 2px 0 #0000000d;--tw-shadow-colored:0 1px 2px 0 var(--tw-shadow-color);box-shadow:var(--tw-ring-offset-shadow,0 0 #0000),var(--tw-ring-shadow,0 0 #0000),var(--tw-shadow)}.focus\:outline-offset-1:focus{outline-offset:1px}.active\:border-zinc-400:active{--tw-border-opacity:1;border-color:rgb(161 161 170/var(--tw-border-opacity))}.disabled\:cursor-default:disabled{cursor:default}.disabled\:outline-none:disabled{outline:2px solid #0000;outline-offset:2px}.group[open] .group-open\:-rotate-90{--tw-rotate:-90deg;transform:translate(var(--tw-translate-x),var(--tw-translate-y)) rotate(var(--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y)) scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y))}.group[open] .group-open\:bg-black\/20{background-color:#0003}.group[open] .group-open\:backdrop-blur-sm{--tw-backdrop-blur:blur(4px);-webkit-backdrop-filter:var(--tw-backdrop-blur) var(--tw-backdrop-brightness) var(--tw-backdrop-contrast) var(--tw-backdrop-grayscale) var(--tw-backdrop-hue-rotate) var(--tw-backdrop-invert) var(--tw-backdrop-opacity) var(--tw-backdrop-saturate) var(--tw-backdrop-sepia);backdrop-filter:var(--tw-backdrop-blur) var(--tw-backdrop-brightness) var(--tw-backdrop-contrast) var(--tw-backdrop-grayscale) var(--tw-backdrop-hue-rotate) var(--tw-backdrop-invert) var(--tw-backdrop-opacity) var(--tw-backdrop-saturate) var(--tw-backdrop-sepia)}.group:hover .group-hover\:block{display:block}.group:hover .group-hover\:fill-zinc-800{fill:#27272a}.group:hover .group-hover\:fill-zinc-500{fill:#71717a}.group:hover .group-hover\:stroke-zinc-800{stroke:#27272a}.group:hover .group-hover\:text-zinc-600{--tw-text-opacity:1;color:rgb(82 82 91/var(--tw-text-opacity))}.group:hover .group-hover\:text-zinc-900{--tw-text-opacity:1;color:rgb(24 24 27/var(--tw-text-opacity))}.group:focus .group-focus\:block{display:block}.group:focus-visible .group-focus-visible\:fill-zinc-800{fill:#27272a}.group:focus-visible .group-focus-visible\:stroke-zinc-800{stroke:#27272a}.group.active .group-\[\.active\]\:border-zinc-200{--tw-border-opacity:1;border-color:rgb(228 228 231/var(--tw-border-opacity))}.group.active .group-\[\.active\]\:bg-zinc-100{--tw-bg-opacity:1;background-color:rgb(244 244 245/var(--tw-bg-opacity))}.group.active .group-\[\.active\]\:font-medium{font-weight:500}.group.active .group-\[\.active\]\:text-zinc-800{--tw-text-opacity:1;color:rgb(39 39 42/var(--tw-text-opacity))}@media (prefers-reduced-motion:no-preference){.motion-safe\:transition-transform{transition-property:transform;transition-timing-function:cubic-bezier(.4,0,.2,1);transition-duration:.15s}.motion-safe\:transition-\[transform\2c opacity\]{transition-property:transform,opacity;transition-timing-function:cubic-bezier(.4,0,.2,1);transition-duration:.15s}.motion-safe\:duration-500{transition-duration:.5s}.motion-safe\:duration-300{transition-duration:.3s}.motion-safe\:ease-elastic-3{transition-timing-function:var(--ease-elastic-3)}.motion-safe\:ease-elastic-4{transition-timing-function:var(--ease-elastic-4)}.motion-safe\:ease-out-5{transition-timing-function:var(--ease-out-5)}}.dark .dark\:translate-x-\[-7px\]{--tw-translate-x:-7px}.dark .dark\:rotate-\[-25deg\],.dark .dark\:translate-x-\[-7px\]{transform:translate(var(--tw-translate-x),var(--tw-translate-y)) rotate(var(--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y)) scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y))}.dark .dark\:rotate-\[-25deg\]{--tw-rotate:-25deg}.dark .dark\:scale-\[1\.75\]{--tw-scale-x:1.75;--tw-scale-y:1.75;transform:translate(var(--tw-translate-x),var(--tw-translate-y)) rotate(var(--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y)) scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y))}.dark .dark\:border-zinc-600{--tw-border-opacity:1;border-color:rgb(82 82 91/var(--tw-border-opacity))}.dark .dark\:border-neutral-600{--tw-border-opacity:1;border-color:rgb(82 82 82/var(--tw-border-opacity))}.dark .dark\:border-stone-800{--tw-border-opacity:1;border-color:rgb(41 37 36/var(--tw-border-opacity))}.dark .dark\:border-zinc-700\/50{border-color:#3f3f4680}.dark .dark\:border-black{--tw-border-opacity:1;border-color:rgb(0 0 0/var(--tw-border-opacity))}.dark .dark\:border-b-black{--tw-border-opacity:1;border-bottom-color:rgb(0 0 0/var(--tw-border-opacity))}.dark .dark\:bg-neutral-900{--tw-bg-opacity:1;background-color:rgb(23 23 23/var(--tw-bg-opacity))}.dark .dark\:bg-zinc-800\/60{background-color:#27272a99}.dark .dark\:bg-zinc-600\/10{background-color:#52525b1a}.dark .dark\:bg-stone-800{--tw-bg-opacity:1;background-color:rgb(41 37 36/var(--tw-bg-opacity))}.dark .dark\:bg-white\/0{background-color:#fff0}.dark .dark\:bg-zinc-900{--tw-bg-opacity:1;background-color:rgb(24 24 27/var(--tw-bg-opacity))}.dark .dark\:bg-black{--tw-bg-opacity:1;background-color:rgb(0 0 0/var(--tw-bg-opacity))}.dark .dark\:from-black{--tw-gradient-from:#000;--tw-gradient-to:#0000;--tw-gradient-stops:var(--tw-gradient-from),var(--tw-gradient-to)}.dark .dark\:to-stone-900{--tw-gradient-to:#1c1917}.dark .dark\:fill-zinc-200{fill:#e4e4e7}.dark .dark\:stroke-zinc-200{stroke:#e4e4e7}.dark .dark\:text-white{--tw-text-opacity:1;color:rgb(255 255 255/var(--tw-text-opacity))}.dark .dark\:text-zinc-100{--tw-text-opacity:1;color:rgb(244 244 245/var(--tw-text-opacity))}.dark .dark\:text-zinc-300{--tw-text-opacity:1;color:rgb(212 212 216/var(--tw-text-opacity))}.dark .dark\:text-zinc-200{--tw-text-opacity:1;color:rgb(228 228 231/var(--tw-text-opacity))}.dark .dark\:text-neutral-100{--tw-text-opacity:1;color:rgb(245 245 245/var(--tw-text-opacity))}.dark .dark\:text-zinc-400{--tw-text-opacity:1;color:rgb(161 161 170/var(--tw-text-opacity))}.dark .dark\:text-inherit{color:inherit}.dark .dark\:text-zinc-500{--tw-text-opacity:1;color:rgb(113 113 122/var(--tw-text-opacity))}.dark .dark\:opacity-0{opacity:0}.dark .dark\:invert{--tw-invert:invert(100%);filter:var(--tw-blur) var(--tw-brightness) var(--tw-contrast) var(--tw-grayscale) var(--tw-hue-rotate) var(--tw-invert) var(--tw-saturate) var(--tw-sepia) var(--tw-drop-shadow)}.dark .dark\:hover\:border-zinc-500:hover{--tw-border-opacity:1;border-color:rgb(113 113 122/var(--tw-border-opacity))}.dark .dark\:hover\:border-zinc-400:hover{--tw-border-opacity:1;border-color:rgb(161 161 170/var(--tw-border-opacity))}.dark .dark\:hover\:bg-zinc-900:hover{--tw-bg-opacity:1;background-color:rgb(24 24 27/var(--tw-bg-opacity))}.dark .dark\:hover\:text-white:hover{--tw-text-opacity:1;color:rgb(255 255 255/var(--tw-text-opacity))}.dark .dark\:hover\:text-zinc-100:hover{--tw-text-opacity:1;color:rgb(244 244 245/var(--tw-text-opacity))}.dark .dark\:active\:border-zinc-400:active{--tw-border-opacity:1;border-color:rgb(161 161 170/var(--tw-border-opacity))}.group[open] .dark .group-open\:dark\:bg-white\/20{background-color:#fff3}.dark .group:hover .dark\:group-hover\:fill-zinc-100{fill:#f4f4f5}.dark .group:hover .dark\:group-hover\:stroke-zinc-100{stroke:#f4f4f5}.dark .group:hover .dark\:group-hover\:text-zinc-400{--tw-text-opacity:1;color:rgb(161 161 170/var(--tw-text-opacity))}.dark .group:hover .dark\:group-hover\:text-white{--tw-text-opacity:1;color:rgb(255 255 255/var(--tw-text-opacity))}.dark .group:hover .dark\:group-hover\:text-zinc-300{--tw-text-opacity:1;color:rgb(212 212 216/var(--tw-text-opacity))}.dark .group:focus-visible .dark\:group-focus-visible\:fill-zinc-100{fill:#f4f4f5}.dark .group:focus-visible .dark\:group-focus-visible\:stroke-zinc-100{stroke:#f4f4f5}.group.active .dark .group-\[\.active\]\:dark\:text-zinc-300{--tw-text-opacity:1;color:rgb(212 212 216/var(--tw-text-opacity))}@media (prefers-reduced-motion:no-preference){.dark .dark\:motion-safe\:delay-300{transition-delay:.3s}.dark .dark\:motion-safe\:duration-\[250ms\]{transition-duration:.25s}.dark .dark\:motion-safe\:duration-150{transition-duration:.15s}.dark .dark\:motion-safe\:ease-3{transition-timing-function:var(--ease-3)}}@media (min-width:640px){.sm\:m-0{margin:0}.sm\:mx-0{margin-left:0;margin-right:0}.sm\:mb-10{margin-bottom:2.5rem}.sm\:mt-0{margin-top:0}.sm\:mb-0{margin-bottom:0}.sm\:ml-0{margin-left:0}.sm\:ml-6{margin-left:1.5rem}.sm\:mr-0{margin-right:0}.sm\:block{display:block}.sm\:flex{display:flex}.sm\:items-center{align-items:center}.sm\:rounded{border-radius:.25rem}.sm\:border-x{border-right-width:1px}.sm\:border-l,.sm\:border-x{border-left-width:1px}.sm\:px-6{padding-left:1.5rem;padding-right:1.5rem}.sm\:px-0{padding-left:0;padding-right:0}.sm\:py-12{padding-top:3rem;padding-bottom:3rem}.sm\:px-7{padding-left:1.75rem;padding-right:1.75rem}.sm\:py-6{padding-top:1.5rem;padding-bottom:1.5rem}.sm\:pt-10{padding-top:2.5rem}.sm\:pb-12{padding-bottom:3rem}.sm\:pr-2{padding-right:.5rem}.sm\:pl-2{padding-left:.5rem}.sm\:text-3xl{font-size:1.875rem;line-height:2.25rem}.dark .dark\:sm\:border-l-zinc-600{--tw-border-opacity:1;border-left-color:rgb(82 82 91/var(--tw-border-opacity))}}@media (min-width:768px){.md\:flex{display:flex}.md\:h-\[500px\]{height:500px}.md\:h-40{height:10rem}.md\:w-1\/2{width:50%}.md\:grid-cols-2{grid-template-columns:repeat(2,minmax(0,1fr))}.md\:items-stretch{align-items:stretch}.md\:whitespace-nowrap{white-space:nowrap}.md\:text-6xl{font-size:3.75rem;line-height:1}.md\:text-5xl{font-size:3rem;line-height:1}.md\:text-4xl{font-size:2.25rem;line-height:2.5rem}.md\:leading-tight{line-height:1.25}}@media (min-width:1024px){.lg\:mr-9{margin-right:2.25rem}.lg\:block{display:block}.lg\:flex{display:flex}.lg\:hidden{display:none}.lg\:max-w-6xl{max-width:72rem}.lg\:justify-center{justify-content:center}.lg\:px-8{padding-left:2rem;padding-right:2rem}.lg\:pl-\[440px\]{padding-left:440px}.lg\:pl-8{padding-left:2rem}.lg\:text-center{text-align:center}.lg\:text-7xl{font-size:4.5rem;line-height:1}.open\:lg\:hidden[open]{display:none}.dark .lg\:dark\:block{display:block}.dark .lg\:dark\:hidden{display:none}}@media (min-width:1280px){.xl\:h-52{height:13rem}.xl\:max-w-screen-xl{max-width:1280px}.xl\:grid-cols-4{grid-template-columns:repeat(4,minmax(0,1fr))}.xl\:items-start{align-items:flex-start}.xl\:py-6{padding-top:1.5rem;padding-bottom:1.5rem}}@media (min-width:1536px){.\32xl\:mx-10{margin-left:2.5rem;margin-right:2.5rem}.\32xl\:block{display:block}.\32xl\:text-base{font-size:1rem;line-height:1.5rem}}@media (min-height:768px){.tall\:sticky{position:sticky}.tall\:top-0{top:0}.tall\:top-16{top:4rem}}.\[\&_\.highlight\]\:h-full .highlight,.\[\&_code\]\:h-full code,.\[\&_pre\]\:h-full pre{height:100%}.\[\&_a\.active\]\:pl-2 a.active{padding-left:.5rem}.\[\&_a\.active\]\:text-zinc-700 a.active{--tw-text-opacity:1;color:rgb(63 63 70/var(--tw-text-opacity))}.dark .\[\&_a\.active\]\:dark\:text-zinc-400 a.active{--tw-text-opacity:1;color:rgb(161 161 170/var(--tw-text-opacity))}.\[\&_a\:hover\]\:border-zinc-700 a:hover{--tw-border-opacity:1;border-color:rgb(63 63 70/var(--tw-border-opacity))}.\[\&_a\:hover\]\:text-black a:hover{--tw-text-opacity:1;color:rgb(0 0 0/var(--tw-text-opacity))}.\[\&_a\:hover\]\:text-white a:hover{--tw-text-opacity:1;color:rgb(255 255 255/var(--tw-text-opacity))}.dark .\[\&_a\:hover\]\:dark\:border-zinc-400 a:hover{--tw-border-opacity:1;border-color:rgb(161 161 170/var(--tw-border-opacity))}.dark .\[\&_a\:hover\]\:dark\:text-zinc-100 a:hover{--tw-text-opacity:1;color:rgb(244 244 245/var(--tw-text-opacity))}.\[\&_a\]\:flex a{display:flex}.\[\&_a\]\:h-8 a{height:2rem}.\[\&_a\]\:w-full a{width:100%}.\[\&_a\]\:items-center a{align-items:center}.\[\&_a\]\:border-l a{border-left-width:1px}.\[\&_a\]\:border-transparent a{border-color:#0000}.\[\&_a\]\:pb-1 a{padding-bottom:.25rem}.\[\&_a\]\:pl-3 a{padding-left:.75rem}.\[\&_a\]\:pr-2 a{padding-right:.5rem}.\[\&_a\]\:pt-2 a{padding-top:.5rem}.\[\&_a\]\:pl-6 a{padding-left:1.5rem}.\[\&_a\]\:pr-4 a{padding-right:1rem}.\[\&_a\]\:text-zinc-600 a{--tw-text-opacity:1;color:rgb(82 82 91/var(--tw-text-opacity))}.dark .\[\&_a\]\:dark\:text-zinc-500 a{--tw-text-opacity:1;color:rgb(113 113 122/var(--tw-text-opacity))}.\[\&\.\.ui-disabled\]\:z-0..ui-disabled{z-index:0}.\[\&\.\.ui-disabled\]\:cursor-not-allowed..ui-disabled{cursor:not-allowed}.\[\&\.\.ui-disabled\]\:bg-zinc-300..ui-disabled{--tw-bg-opacity:1;background-color:rgb(212 212 216/var(--tw-bg-opacity))}.\[\&\.\.ui-disabled\]\:text-zinc-400..ui-disabled{--tw-text-opacity:1;color:rgb(161 161 170/var(--tw-text-opacity))}.\[\&\.ui-selected\]\:z-20.ui-selected{z-index:20}.\[\&\.ui-selected\]\:border-b-0.ui-selected{border-bottom-width:0}.\[\&\.ui-selected\]\:border-t-2.ui-selected{border-top-width:2px}.\[\&\.ui-selected\]\:bg-\[\#181818\].ui-selected{--tw-bg-opacity:1;background-color:rgb(24 24 24/var(--tw-bg-opacity))}.\[\&\.ui-selected\]\:text-white.ui-selected{--tw-text-opacity:1;color:rgb(255 255 255/var(--tw-text-opacity))}.\[\&\.ui-hidden\]\:hidden.ui-hidden{display:none}.\[\&_div\.highlight\]\:m-0 div.highlight{margin:0}.\[\&_div\.highlight\]\:border-0 div.highlight{border-width:0}.\[\&_a\:first-child\]\:rounded-t-md a:first-child{border-top-left-radius:.375rem;border-top-right-radius:.375rem}.\[\&_a\:last-child\]\:rounded-b-md a:last-child{border-bottom-right-radius:.375rem;border-bottom-left-radius:.375rem}.\[\&_a\.active\:before\]\:pr-1 a.active:before{padding-right:.25rem}.\[\&_a\.active\:before\]\:content-\[\'\2713\'\] a.active:before{--tw-content:"✓";content:var(--tw-content)}
+/*
+! tailwindcss v3.2.4 | MIT License | https://tailwindcss.com
+*/
+
+/*
+1. Prevent padding and border from affecting element width. (https://github.com/mozdevs/cssremedy/issues/4)
+2. Allow adding a border to an element by just adding a border-width. (https://github.com/tailwindcss/tailwindcss/pull/116)
+*/
+
+*,
+::before,
+::after {
+  box-sizing: border-box;
+  /* 1 */
+  border-width: 0;
+  /* 2 */
+  border-style: solid;
+  /* 2 */
+  border-color: #e5e7eb;
+  /* 2 */
+}
+
+::before,
+::after {
+  --tw-content: '';
+}
+
+/*
+1. Use a consistent sensible line-height in all browsers.
+2. Prevent adjustments of font size after orientation changes in iOS.
+3. Use a more readable tab size.
+4. Use the user's configured `sans` font-family by default.
+5. Use the user's configured `sans` font-feature-settings by default.
+*/
+
+html {
+  line-height: 1.5;
+  /* 1 */
+  -webkit-text-size-adjust: 100%;
+  /* 2 */
+  -moz-tab-size: 4;
+  /* 3 */
+  -o-tab-size: 4;
+     tab-size: 4;
+  /* 3 */
+  font-family: silka, sans-serif;
+  /* 4 */
+  font-feature-settings: normal;
+  /* 5 */
+}
+
+/*
+1. Remove the margin in all browsers.
+2. Inherit line-height from `html` so users can set them as a class directly on the `html` element.
+*/
+
+body {
+  margin: 0;
+  /* 1 */
+  line-height: inherit;
+  /* 2 */
+}
+
+/*
+1. Add the correct height in Firefox.
+2. Correct the inheritance of border color in Firefox. (https://bugzilla.mozilla.org/show_bug.cgi?id=190655)
+3. Ensure horizontal rules are visible by default.
+*/
+
+hr {
+  height: 0;
+  /* 1 */
+  color: inherit;
+  /* 2 */
+  border-top-width: 1px;
+  /* 3 */
+}
+
+/*
+Add the correct text decoration in Chrome, Edge, and Safari.
+*/
+
+abbr:where([title]) {
+  -webkit-text-decoration: underline dotted;
+          text-decoration: underline dotted;
+}
+
+/*
+Remove the default font size and weight for headings.
+*/
+
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+  font-size: inherit;
+  font-weight: inherit;
+}
+
+/*
+Reset links to optimize for opt-in styling instead of opt-out.
+*/
+
+a {
+  color: inherit;
+  text-decoration: inherit;
+}
+
+/*
+Add the correct font weight in Edge and Safari.
+*/
+
+b,
+strong {
+  font-weight: bolder;
+}
+
+/*
+1. Use the user's configured `mono` font family by default.
+2. Correct the odd `em` font sizing in all browsers.
+*/
+
+code,
+kbd,
+samp,
+pre {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+  /* 1 */
+  font-size: 1em;
+  /* 2 */
+}
+
+/*
+Add the correct font size in all browsers.
+*/
+
+small {
+  font-size: 80%;
+}
+
+/*
+Prevent `sub` and `sup` elements from affecting the line height in all browsers.
+*/
+
+sub,
+sup {
+  font-size: 75%;
+  line-height: 0;
+  position: relative;
+  vertical-align: baseline;
+}
+
+sub {
+  bottom: -0.25em;
+}
+
+sup {
+  top: -0.5em;
+}
+
+/*
+1. Remove text indentation from table contents in Chrome and Safari. (https://bugs.chromium.org/p/chromium/issues/detail?id=999088, https://bugs.webkit.org/show_bug.cgi?id=201297)
+2. Correct table border color inheritance in all Chrome and Safari. (https://bugs.chromium.org/p/chromium/issues/detail?id=935729, https://bugs.webkit.org/show_bug.cgi?id=195016)
+3. Remove gaps between table borders by default.
+*/
+
+table {
+  text-indent: 0;
+  /* 1 */
+  border-color: inherit;
+  /* 2 */
+  border-collapse: collapse;
+  /* 3 */
+}
+
+/*
+1. Change the font styles in all browsers.
+2. Remove the margin in Firefox and Safari.
+3. Remove default padding in all browsers.
+*/
+
+button,
+input,
+optgroup,
+select,
+textarea {
+  font-family: inherit;
+  /* 1 */
+  font-size: 100%;
+  /* 1 */
+  font-weight: inherit;
+  /* 1 */
+  line-height: inherit;
+  /* 1 */
+  color: inherit;
+  /* 1 */
+  margin: 0;
+  /* 2 */
+  padding: 0;
+  /* 3 */
+}
+
+/*
+Remove the inheritance of text transform in Edge and Firefox.
+*/
+
+button,
+select {
+  text-transform: none;
+}
+
+/*
+1. Correct the inability to style clickable types in iOS and Safari.
+2. Remove default button styles.
+*/
+
+button,
+[type='button'],
+[type='reset'],
+[type='submit'] {
+  -webkit-appearance: button;
+  /* 1 */
+  background-color: transparent;
+  /* 2 */
+  background-image: none;
+  /* 2 */
+}
+
+/*
+Use the modern Firefox focus style for all focusable elements.
+*/
+
+:-moz-focusring {
+  outline: auto;
+}
+
+/*
+Remove the additional `:invalid` styles in Firefox. (https://github.com/mozilla/gecko-dev/blob/2f9eacd9d3d995c937b4251a5557d95d494c9be1/layout/style/res/forms.css#L728-L737)
+*/
+
+:-moz-ui-invalid {
+  box-shadow: none;
+}
+
+/*
+Add the correct vertical alignment in Chrome and Firefox.
+*/
+
+progress {
+  vertical-align: baseline;
+}
+
+/*
+Correct the cursor style of increment and decrement buttons in Safari.
+*/
+
+::-webkit-inner-spin-button,
+::-webkit-outer-spin-button {
+  height: auto;
+}
+
+/*
+1. Correct the odd appearance in Chrome and Safari.
+2. Correct the outline style in Safari.
+*/
+
+[type='search'] {
+  -webkit-appearance: textfield;
+  /* 1 */
+  outline-offset: -2px;
+  /* 2 */
+}
+
+/*
+Remove the inner padding in Chrome and Safari on macOS.
+*/
+
+::-webkit-search-decoration {
+  -webkit-appearance: none;
+}
+
+/*
+1. Correct the inability to style clickable types in iOS and Safari.
+2. Change font properties to `inherit` in Safari.
+*/
+
+::-webkit-file-upload-button {
+  -webkit-appearance: button;
+  /* 1 */
+  font: inherit;
+  /* 2 */
+}
+
+/*
+Add the correct display in Chrome and Safari.
+*/
+
+summary {
+  display: list-item;
+}
+
+/*
+Removes the default spacing and border for appropriate elements.
+*/
+
+blockquote,
+dl,
+dd,
+h1,
+h2,
+h3,
+h4,
+h5,
+h6,
+hr,
+figure,
+p,
+pre {
+  margin: 0;
+}
+
+fieldset {
+  margin: 0;
+  padding: 0;
+}
+
+legend {
+  padding: 0;
+}
+
+ol,
+ul,
+menu {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+/*
+Prevent resizing textareas horizontally by default.
+*/
+
+textarea {
+  resize: vertical;
+}
+
+/*
+1. Reset the default placeholder opacity in Firefox. (https://github.com/tailwindlabs/tailwindcss/issues/3300)
+2. Set the default placeholder color to the user's configured gray 400 color.
+*/
+
+input::-moz-placeholder, textarea::-moz-placeholder {
+  opacity: 1;
+  /* 1 */
+  color: #9ca3af;
+  /* 2 */
+}
+
+input::placeholder,
+textarea::placeholder {
+  opacity: 1;
+  /* 1 */
+  color: #9ca3af;
+  /* 2 */
+}
+
+/*
+Set the default cursor for buttons.
+*/
+
+button,
+[role="button"] {
+  cursor: pointer;
+}
+
+/*
+Make sure disabled buttons don't get the pointer cursor.
+*/
+
+:disabled {
+  cursor: default;
+}
+
+/*
+1. Make replaced elements `display: block` by default. (https://github.com/mozdevs/cssremedy/issues/14)
+2. Add `vertical-align: middle` to align replaced elements more sensibly by default. (https://github.com/jensimmons/cssremedy/issues/14#issuecomment-634934210)
+   This can trigger a poorly considered lint error in some tools but is included by design.
+*/
+
+img,
+svg,
+video,
+canvas,
+audio,
+iframe,
+embed,
+object {
+  display: block;
+  /* 1 */
+  vertical-align: middle;
+  /* 2 */
+}
+
+/*
+Constrain images and videos to the parent width and preserve their intrinsic aspect ratio. (https://github.com/mozdevs/cssremedy/issues/14)
+*/
+
+img,
+video {
+  max-width: 100%;
+  height: auto;
+}
+
+/* Make elements with the HTML hidden attribute stay hidden by default */
+
+[hidden] {
+  display: none;
+}
+
+@font-face {
+  font-family: silka;
+
+  src: url("./silka.woff2") format("woff2");
+
+  font-display: swap;
+
+  font-style: normal;
+
+  font-weight: 300;
+}
+
+@font-face {
+  font-family: silka;
+
+  src: url("./silka-medium.woff2") format("woff2");
+
+  font-display: swap;
+
+  font-style: normal;
+
+  font-weight: 400;
+}
+
+@font-face {
+  font-family: silka;
+
+  src: url("./silka-semibold.woff2") format("woff2");
+
+  font-display: swap;
+
+  font-style: normal;
+
+  font-weight: 600;
+}
+
+:root {
+  --ease-3: cubic-bezier(0.25, 0, 0.3, 1);
+  --ease-out-5: cubic-bezier(0, 0, 0, 1);
+  --ease-elastic-3: cubic-bezier(0.5, 1.25, 0.75, 1.25);
+  --ease-elastic-4: cubic-bezier(0.5, 1.5, 0.75, 1.25);
+}
+
+*, ::before, ::after {
+  --tw-border-spacing-x: 0;
+  --tw-border-spacing-y: 0;
+  --tw-translate-x: 0;
+  --tw-translate-y: 0;
+  --tw-rotate: 0;
+  --tw-skew-x: 0;
+  --tw-skew-y: 0;
+  --tw-scale-x: 1;
+  --tw-scale-y: 1;
+  --tw-pan-x:  ;
+  --tw-pan-y:  ;
+  --tw-pinch-zoom:  ;
+  --tw-scroll-snap-strictness: proximity;
+  --tw-ordinal:  ;
+  --tw-slashed-zero:  ;
+  --tw-numeric-figure:  ;
+  --tw-numeric-spacing:  ;
+  --tw-numeric-fraction:  ;
+  --tw-ring-inset:  ;
+  --tw-ring-offset-width: 0px;
+  --tw-ring-offset-color: #fff;
+  --tw-ring-color: rgb(59 130 246 / 0.5);
+  --tw-ring-offset-shadow: 0 0 #0000;
+  --tw-ring-shadow: 0 0 #0000;
+  --tw-shadow: 0 0 #0000;
+  --tw-shadow-colored: 0 0 #0000;
+  --tw-blur:  ;
+  --tw-brightness:  ;
+  --tw-contrast:  ;
+  --tw-grayscale:  ;
+  --tw-hue-rotate:  ;
+  --tw-invert:  ;
+  --tw-saturate:  ;
+  --tw-sepia:  ;
+  --tw-drop-shadow:  ;
+  --tw-backdrop-blur:  ;
+  --tw-backdrop-brightness:  ;
+  --tw-backdrop-contrast:  ;
+  --tw-backdrop-grayscale:  ;
+  --tw-backdrop-hue-rotate:  ;
+  --tw-backdrop-invert:  ;
+  --tw-backdrop-opacity:  ;
+  --tw-backdrop-saturate:  ;
+  --tw-backdrop-sepia:  ;
+}
+
+::backdrop {
+  --tw-border-spacing-x: 0;
+  --tw-border-spacing-y: 0;
+  --tw-translate-x: 0;
+  --tw-translate-y: 0;
+  --tw-rotate: 0;
+  --tw-skew-x: 0;
+  --tw-skew-y: 0;
+  --tw-scale-x: 1;
+  --tw-scale-y: 1;
+  --tw-pan-x:  ;
+  --tw-pan-y:  ;
+  --tw-pinch-zoom:  ;
+  --tw-scroll-snap-strictness: proximity;
+  --tw-ordinal:  ;
+  --tw-slashed-zero:  ;
+  --tw-numeric-figure:  ;
+  --tw-numeric-spacing:  ;
+  --tw-numeric-fraction:  ;
+  --tw-ring-inset:  ;
+  --tw-ring-offset-width: 0px;
+  --tw-ring-offset-color: #fff;
+  --tw-ring-color: rgb(59 130 246 / 0.5);
+  --tw-ring-offset-shadow: 0 0 #0000;
+  --tw-ring-shadow: 0 0 #0000;
+  --tw-shadow: 0 0 #0000;
+  --tw-shadow-colored: 0 0 #0000;
+  --tw-blur:  ;
+  --tw-brightness:  ;
+  --tw-contrast:  ;
+  --tw-grayscale:  ;
+  --tw-hue-rotate:  ;
+  --tw-invert:  ;
+  --tw-saturate:  ;
+  --tw-sepia:  ;
+  --tw-drop-shadow:  ;
+  --tw-backdrop-blur:  ;
+  --tw-backdrop-brightness:  ;
+  --tw-backdrop-contrast:  ;
+  --tw-backdrop-grayscale:  ;
+  --tw-backdrop-hue-rotate:  ;
+  --tw-backdrop-invert:  ;
+  --tw-backdrop-opacity:  ;
+  --tw-backdrop-saturate:  ;
+  --tw-backdrop-sepia:  ;
+}
+
+.pointer-events-none {
+  pointer-events: none;
+}
+
+.fixed {
+  position: fixed;
+}
+
+.absolute {
+  position: absolute;
+}
+
+.relative {
+  position: relative;
+}
+
+.sticky {
+  position: sticky;
+}
+
+.inset-0 {
+  top: 0px;
+  right: 0px;
+  bottom: 0px;
+  left: 0px;
+}
+
+.left-0 {
+  left: 0px;
+}
+
+.top-0 {
+  top: 0px;
+}
+
+.bottom-0 {
+  bottom: 0px;
+}
+
+.right-0 {
+  right: 0px;
+}
+
+.top-full {
+  top: 100%;
+}
+
+.-left-1\/2 {
+  left: -50%;
+}
+
+.left-1\/2 {
+  left: 50%;
+}
+
+.z-50 {
+  z-index: 50;
+}
+
+.z-10 {
+  z-index: 10;
+}
+
+.z-0 {
+  z-index: 0;
+}
+
+.z-30 {
+  z-index: 30;
+}
+
+.float-right {
+  float: right;
+}
+
+.float-left {
+  float: left;
+}
+
+.m-0 {
+  margin: 0px;
+}
+
+.m-2 {
+  margin: 0.5rem;
+}
+
+.mx-auto {
+  margin-left: auto;
+  margin-right: auto;
+}
+
+.my-6 {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+}
+
+.-mx-4 {
+  margin-left: -1rem;
+  margin-right: -1rem;
+}
+
+.mx-\[0\.1rem\] {
+  margin-left: 0.1rem;
+  margin-right: 0.1rem;
+}
+
+.mr-auto {
+  margin-right: auto;
+}
+
+.ml-2 {
+  margin-left: 0.5rem;
+}
+
+.ml-3 {
+  margin-left: 0.75rem;
+}
+
+.mb-8 {
+  margin-bottom: 2rem;
+}
+
+.mb-6 {
+  margin-bottom: 1.5rem;
+}
+
+.mr-6 {
+  margin-right: 1.5rem;
+}
+
+.mb-2 {
+  margin-bottom: 0.5rem;
+}
+
+.mt-6 {
+  margin-top: 1.5rem;
+}
+
+.mt-10 {
+  margin-top: 2.5rem;
+}
+
+.mb-5 {
+  margin-bottom: 1.25rem;
+}
+
+.mb-3 {
+  margin-bottom: 0.75rem;
+}
+
+.ml-auto {
+  margin-left: auto;
+}
+
+.mt-16 {
+  margin-top: 4rem;
+}
+
+.mr-5 {
+  margin-right: 1.25rem;
+}
+
+.ml-4 {
+  margin-left: 1rem;
+}
+
+.mr-4 {
+  margin-right: 1rem;
+}
+
+.ml-0 {
+  margin-left: 0px;
+}
+
+.mb-4 {
+  margin-bottom: 1rem;
+}
+
+.mb-10 {
+  margin-bottom: 2.5rem;
+}
+
+.-mt-1 {
+  margin-top: -0.25rem;
+}
+
+.-ml-1 {
+  margin-left: -0.25rem;
+}
+
+.mt-2 {
+  margin-top: 0.5rem;
+}
+
+.mb-1 {
+  margin-bottom: 0.25rem;
+}
+
+.mt-1 {
+  margin-top: 0.25rem;
+}
+
+.ml-8 {
+  margin-left: 2rem;
+}
+
+.block {
+  display: block;
+}
+
+.inline-block {
+  display: inline-block;
+}
+
+.flex {
+  display: flex;
+}
+
+.grid {
+  display: grid;
+}
+
+.hidden {
+  display: none;
+}
+
+.h-14 {
+  height: 3.5rem;
+}
+
+.h-10 {
+  height: 2.5rem;
+}
+
+.h-8 {
+  height: 2rem;
+}
+
+.h-5 {
+  height: 1.25rem;
+}
+
+.h-6 {
+  height: 1.5rem;
+}
+
+.h-20 {
+  height: 5rem;
+}
+
+.h-36 {
+  height: 9rem;
+}
+
+.h-full {
+  height: 100%;
+}
+
+.h-screen {
+  height: 100vh;
+}
+
+.h-fit {
+  height: -moz-fit-content;
+  height: fit-content;
+}
+
+.h-7 {
+  height: 1.75rem;
+}
+
+.h-12 {
+  height: 3rem;
+}
+
+.h-0 {
+  height: 0px;
+}
+
+.h-4 {
+  height: 1rem;
+}
+
+.max-h-\[32px\] {
+  max-height: 32px;
+}
+
+.max-h-96 {
+  max-height: 24rem;
+}
+
+.min-h-screen {
+  min-height: 100vh;
+}
+
+.w-full {
+  width: 100%;
+}
+
+.w-8 {
+  width: 2rem;
+}
+
+.w-5 {
+  width: 1.25rem;
+}
+
+.w-14 {
+  width: 3.5rem;
+}
+
+.w-20 {
+  width: 5rem;
+}
+
+.w-10 {
+  width: 2.5rem;
+}
+
+.w-72 {
+  width: 18rem;
+}
+
+.w-1\/2 {
+  width: 50%;
+}
+
+.w-4 {
+  width: 1rem;
+}
+
+.w-64 {
+  width: 16rem;
+}
+
+.w-7 {
+  width: 1.75rem;
+}
+
+.w-0 {
+  width: 0px;
+}
+
+.w-6 {
+  width: 1.5rem;
+}
+
+.max-w-\[100rem\] {
+  max-width: 100rem;
+}
+
+.max-w-full {
+  max-width: 100%;
+}
+
+.max-w-4xl {
+  max-width: 56rem;
+}
+
+.max-w-6xl {
+  max-width: 72rem;
+}
+
+.max-w-md {
+  max-width: 28rem;
+}
+
+.max-w-5xl {
+  max-width: 64rem;
+}
+
+.max-w-screen-sm {
+  max-width: 640px;
+}
+
+.max-w-\[40rem\] {
+  max-width: 40rem;
+}
+
+.flex-grow {
+  flex-grow: 1;
+}
+
+.origin-center {
+  transform-origin: center;
+}
+
+.rotate-180 {
+  --tw-rotate: 180deg;
+  transform: translate(var(--tw-translate-x), var(--tw-translate-y)) rotate(var(--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y)) scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y));
+}
+
+.rotate-90 {
+  --tw-rotate: 90deg;
+  transform: translate(var(--tw-translate-x), var(--tw-translate-y)) rotate(var(--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y)) scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y));
+}
+
+.scale-100 {
+  --tw-scale-x: 1;
+  --tw-scale-y: 1;
+  transform: translate(var(--tw-translate-x), var(--tw-translate-y)) rotate(var(--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y)) scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y));
+}
+
+.transform-gpu {
+  transform: translate3d(var(--tw-translate-x), var(--tw-translate-y), 0) rotate(var(--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y)) scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y));
+}
+
+.cursor-pointer {
+  cursor: pointer;
+}
+
+.touch-manipulation {
+  touch-action: manipulation;
+}
+
+.select-none {
+  -webkit-user-select: none;
+     -moz-user-select: none;
+          user-select: none;
+}
+
+.appearance-none {
+  -webkit-appearance: none;
+     -moz-appearance: none;
+          appearance: none;
+}
+
+.grid-cols-1 {
+  grid-template-columns: repeat(1, minmax(0, 1fr));
+}
+
+.flex-col {
+  flex-direction: column;
+}
+
+.items-start {
+  align-items: flex-start;
+}
+
+.items-end {
+  align-items: flex-end;
+}
+
+.items-center {
+  align-items: center;
+}
+
+.justify-start {
+  justify-content: flex-start;
+}
+
+.justify-center {
+  justify-content: center;
+}
+
+.justify-evenly {
+  justify-content: space-evenly;
+}
+
+.gap-x-4 {
+  -moz-column-gap: 1rem;
+       column-gap: 1rem;
+}
+
+.gap-y-6 {
+  row-gap: 1.5rem;
+}
+
+.space-x-8 > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-x-reverse: 0;
+  margin-right: calc(2rem * var(--tw-space-x-reverse));
+  margin-left: calc(2rem * calc(1 - var(--tw-space-x-reverse)));
+}
+
+.space-x-1 > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-x-reverse: 0;
+  margin-right: calc(0.25rem * var(--tw-space-x-reverse));
+  margin-left: calc(0.25rem * calc(1 - var(--tw-space-x-reverse)));
+}
+
+.space-x-4 > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-x-reverse: 0;
+  margin-right: calc(1rem * var(--tw-space-x-reverse));
+  margin-left: calc(1rem * calc(1 - var(--tw-space-x-reverse)));
+}
+
+.overflow-hidden {
+  overflow: hidden;
+}
+
+.overflow-x-auto {
+  overflow-x: auto;
+}
+
+.overflow-y-auto {
+  overflow-y: auto;
+}
+
+.overflow-x-hidden {
+  overflow-x: hidden;
+}
+
+.overflow-y-hidden {
+  overflow-y: hidden;
+}
+
+.overscroll-contain {
+  overscroll-behavior: contain;
+}
+
+.scroll-smooth {
+  scroll-behavior: smooth;
+}
+
+.whitespace-nowrap {
+  white-space: nowrap;
+}
+
+.rounded {
+  border-radius: 0.25rem;
+}
+
+.rounded-2xl {
+  border-radius: 1rem;
+}
+
+.rounded-md {
+  border-radius: 0.375rem;
+}
+
+.rounded-t {
+  border-top-left-radius: 0.25rem;
+  border-top-right-radius: 0.25rem;
+}
+
+.rounded-b {
+  border-bottom-right-radius: 0.25rem;
+  border-bottom-left-radius: 0.25rem;
+}
+
+.border {
+  border-width: 1px;
+}
+
+.border-2 {
+  border-width: 2px;
+}
+
+.border-y {
+  border-top-width: 1px;
+  border-bottom-width: 1px;
+}
+
+.border-b {
+  border-bottom-width: 1px;
+}
+
+.border-l-2 {
+  border-left-width: 2px;
+}
+
+.border-t {
+  border-top-width: 1px;
+}
+
+.border-r {
+  border-right-width: 1px;
+}
+
+.border-l {
+  border-left-width: 1px;
+}
+
+.border-r-0 {
+  border-right-width: 0px;
+}
+
+.border-t-0 {
+  border-top-width: 0px;
+}
+
+.border-l-4 {
+  border-left-width: 4px;
+}
+
+.border-r-4 {
+  border-right-width: 4px;
+}
+
+.border-b-8 {
+  border-bottom-width: 8px;
+}
+
+.border-zinc-200 {
+  --tw-border-opacity: 1;
+  border-color: rgb(228 228 231 / var(--tw-border-opacity));
+}
+
+.border-neutral-300 {
+  --tw-border-opacity: 1;
+  border-color: rgb(212 212 212 / var(--tw-border-opacity));
+}
+
+.border-stone-100 {
+  --tw-border-opacity: 1;
+  border-color: rgb(245 245 244 / var(--tw-border-opacity));
+}
+
+.border-zinc-100 {
+  --tw-border-opacity: 1;
+  border-color: rgb(244 244 245 / var(--tw-border-opacity));
+}
+
+.border-transparent {
+  border-color: transparent;
+}
+
+.border-zinc-600 {
+  --tw-border-opacity: 1;
+  border-color: rgb(82 82 91 / var(--tw-border-opacity));
+}
+
+.border-orange-200 {
+  --tw-border-opacity: 1;
+  border-color: rgb(254 215 170 / var(--tw-border-opacity));
+}
+
+.border-zinc-300 {
+  --tw-border-opacity: 1;
+  border-color: rgb(212 212 216 / var(--tw-border-opacity));
+}
+
+.border-yellow-200 {
+  --tw-border-opacity: 1;
+  border-color: rgb(254 240 138 / var(--tw-border-opacity));
+}
+
+.border-rose-200 {
+  --tw-border-opacity: 1;
+  border-color: rgb(254 205 211 / var(--tw-border-opacity));
+}
+
+.border-stone-300 {
+  --tw-border-opacity: 1;
+  border-color: rgb(214 211 209 / var(--tw-border-opacity));
+}
+
+.border-white {
+  --tw-border-opacity: 1;
+  border-color: rgb(255 255 255 / var(--tw-border-opacity));
+}
+
+.border-b-white {
+  --tw-border-opacity: 1;
+  border-bottom-color: rgb(255 255 255 / var(--tw-border-opacity));
+}
+
+.bg-white {
+  --tw-bg-opacity: 1;
+  background-color: rgb(255 255 255 / var(--tw-bg-opacity));
+}
+
+.bg-white\/60 {
+  background-color: rgb(255 255 255 / 0.6);
+}
+
+.bg-zinc-50 {
+  --tw-bg-opacity: 1;
+  background-color: rgb(250 250 250 / var(--tw-bg-opacity));
+}
+
+.bg-stone-200 {
+  --tw-bg-opacity: 1;
+  background-color: rgb(231 229 228 / var(--tw-bg-opacity));
+}
+
+.bg-stone-50 {
+  --tw-bg-opacity: 1;
+  background-color: rgb(250 250 249 / var(--tw-bg-opacity));
+}
+
+.bg-black\/0 {
+  background-color: rgb(0 0 0 / 0);
+}
+
+.bg-zinc-800 {
+  --tw-bg-opacity: 1;
+  background-color: rgb(39 39 42 / var(--tw-bg-opacity));
+}
+
+.bg-orange-100 {
+  --tw-bg-opacity: 1;
+  background-color: rgb(255 237 213 / var(--tw-bg-opacity));
+}
+
+.bg-zinc-100 {
+  --tw-bg-opacity: 1;
+  background-color: rgb(244 244 245 / var(--tw-bg-opacity));
+}
+
+.bg-yellow-100 {
+  --tw-bg-opacity: 1;
+  background-color: rgb(254 249 195 / var(--tw-bg-opacity));
+}
+
+.bg-rose-100 {
+  --tw-bg-opacity: 1;
+  background-color: rgb(255 228 230 / var(--tw-bg-opacity));
+}
+
+.bg-opacity-90 {
+  --tw-bg-opacity: 0.9;
+}
+
+.bg-opacity-\[0\.001\] {
+  --tw-bg-opacity: 0.001;
+}
+
+.bg-gradient-to-br {
+  background-image: linear-gradient(to bottom right, var(--tw-gradient-stops));
+}
+
+.bg-gradient-to-b {
+  background-image: linear-gradient(to bottom, var(--tw-gradient-stops));
+}
+
+.bg-gradient-to-tr {
+  background-image: linear-gradient(to top right, var(--tw-gradient-stops));
+}
+
+.from-amber-400 {
+  --tw-gradient-from: #fbbf24;
+  --tw-gradient-to: rgb(251 191 36 / 0);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to);
+}
+
+.from-emerald-400 {
+  --tw-gradient-from: #34d399;
+  --tw-gradient-to: rgb(52 211 153 / 0);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to);
+}
+
+.from-stone-300 {
+  --tw-gradient-from: #d6d3d1;
+  --tw-gradient-to: rgb(214 211 209 / 0);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to);
+}
+
+.from-lime-400 {
+  --tw-gradient-from: #a3e635;
+  --tw-gradient-to: rgb(163 230 53 / 0);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to);
+}
+
+.via-stone-200 {
+  --tw-gradient-to: rgb(231 229 228 / 0);
+  --tw-gradient-stops: var(--tw-gradient-from), #e7e5e4, var(--tw-gradient-to);
+}
+
+.to-orange-400 {
+  --tw-gradient-to: #fb923c;
+}
+
+.to-blue-500 {
+  --tw-gradient-to: #3b82f6;
+}
+
+.to-stone-400 {
+  --tw-gradient-to: #a8a29e;
+}
+
+.to-lime-600 {
+  --tw-gradient-to: #65a30d;
+}
+
+.bg-clip-text {
+  -webkit-background-clip: text;
+          background-clip: text;
+}
+
+.fill-zinc-700 {
+  fill: #3f3f46;
+}
+
+.fill-zinc-600 {
+  fill: #52525b;
+}
+
+.stroke-transparent {
+  stroke: transparent;
+}
+
+.stroke-zinc-700 {
+  stroke: #3f3f46;
+}
+
+.stroke-2 {
+  stroke-width: 2;
+}
+
+.p-1 {
+  padding: 0.25rem;
+}
+
+.p-\[0\.4rem\] {
+  padding: 0.4rem;
+}
+
+.p-0 {
+  padding: 0px;
+}
+
+.p-4 {
+  padding: 1rem;
+}
+
+.p-2 {
+  padding: 0.5rem;
+}
+
+.px-4 {
+  padding-left: 1rem;
+  padding-right: 1rem;
+}
+
+.px-6 {
+  padding-left: 1.5rem;
+  padding-right: 1.5rem;
+}
+
+.py-9 {
+  padding-top: 2.25rem;
+  padding-bottom: 2.25rem;
+}
+
+.py-6 {
+  padding-top: 1.5rem;
+  padding-bottom: 1.5rem;
+}
+
+.py-8 {
+  padding-top: 2rem;
+  padding-bottom: 2rem;
+}
+
+.py-4 {
+  padding-top: 1rem;
+  padding-bottom: 1rem;
+}
+
+.px-3 {
+  padding-left: 0.75rem;
+  padding-right: 0.75rem;
+}
+
+.py-24 {
+  padding-top: 6rem;
+  padding-bottom: 6rem;
+}
+
+.px-8 {
+  padding-left: 2rem;
+  padding-right: 2rem;
+}
+
+.py-3 {
+  padding-top: 0.75rem;
+  padding-bottom: 0.75rem;
+}
+
+.py-5 {
+  padding-top: 1.25rem;
+  padding-bottom: 1.25rem;
+}
+
+.py-1 {
+  padding-top: 0.25rem;
+  padding-bottom: 0.25rem;
+}
+
+.px-2 {
+  padding-left: 0.5rem;
+  padding-right: 0.5rem;
+}
+
+.px-5 {
+  padding-left: 1.25rem;
+  padding-right: 1.25rem;
+}
+
+.py-2 {
+  padding-top: 0.5rem;
+  padding-bottom: 0.5rem;
+}
+
+.py-7 {
+  padding-top: 1.75rem;
+  padding-bottom: 1.75rem;
+}
+
+.px-1 {
+  padding-left: 0.25rem;
+  padding-right: 0.25rem;
+}
+
+.py-\[0\.2rem\] {
+  padding-top: 0.2rem;
+  padding-bottom: 0.2rem;
+}
+
+.pr-\[max\(0\.75rem\2c env\(safe-area-inset-right\)\)\] {
+  padding-right: max(0.75rem,env(safe-area-inset-right));
+}
+
+.pl-\[max\(0\.75rem\2c env\(safe-area-inset-left\)\)\] {
+  padding-left: max(0.75rem,env(safe-area-inset-left));
+}
+
+.pr-3 {
+  padding-right: 0.75rem;
+}
+
+.pr-\[env\(safe-area-inset-right\)\] {
+  padding-right: env(safe-area-inset-right);
+}
+
+.pl-\[env\(safe-area-inset-left\)\] {
+  padding-left: env(safe-area-inset-left);
+}
+
+.pb-12 {
+  padding-bottom: 3rem;
+}
+
+.pb-3 {
+  padding-bottom: 0.75rem;
+}
+
+.pl-\[max\(1rem\2c env\(safe-area-inset-left\)\)\] {
+  padding-left: max(1rem,env(safe-area-inset-left));
+}
+
+.pr-\[max\(1rem\2c env\(safe-area-inset-right\)\)\] {
+  padding-right: max(1rem,env(safe-area-inset-right));
+}
+
+.pl-2 {
+  padding-left: 0.5rem;
+}
+
+.pb-16 {
+  padding-bottom: 4rem;
+}
+
+.pr-4 {
+  padding-right: 1rem;
+}
+
+.pb-14 {
+  padding-bottom: 3.5rem;
+}
+
+.pt-10 {
+  padding-top: 2.5rem;
+}
+
+.pl-8 {
+  padding-left: 2rem;
+}
+
+.pl-4 {
+  padding-left: 1rem;
+}
+
+.text-center {
+  text-align: center;
+}
+
+.font-sans {
+  font-family: silka, sans-serif;
+}
+
+.font-mono {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+}
+
+.text-2xl {
+  font-size: 1.5rem;
+  line-height: 2rem;
+}
+
+.text-sm {
+  font-size: 0.875rem;
+  line-height: 1.25rem;
+}
+
+.text-5xl {
+  font-size: 3rem;
+  line-height: 1;
+}
+
+.text-4xl {
+  font-size: 2.25rem;
+  line-height: 2.5rem;
+}
+
+.text-base {
+  font-size: 1rem;
+  line-height: 1.5rem;
+}
+
+.text-3xl {
+  font-size: 1.875rem;
+  line-height: 2.25rem;
+}
+
+.text-xl {
+  font-size: 1.25rem;
+  line-height: 1.75rem;
+}
+
+.text-xs {
+  font-size: 0.75rem;
+  line-height: 1rem;
+}
+
+.text-lg {
+  font-size: 1.125rem;
+  line-height: 1.75rem;
+}
+
+.font-bold {
+  font-weight: 700;
+}
+
+.font-semibold {
+  font-weight: 600;
+}
+
+.font-normal {
+  font-weight: 400;
+}
+
+.font-black {
+  font-weight: 900;
+}
+
+.font-extrabold {
+  font-weight: 800;
+}
+
+.font-medium {
+  font-weight: 500;
+}
+
+.uppercase {
+  text-transform: uppercase;
+}
+
+.leading-none {
+  line-height: 1;
+}
+
+.leading-6 {
+  line-height: 1.5rem;
+}
+
+.leading-tight {
+  line-height: 1.25;
+}
+
+.leading-relaxed {
+  line-height: 1.625;
+}
+
+.tracking-tighter {
+  letter-spacing: -0.05em;
+}
+
+.tracking-tight {
+  letter-spacing: -0.025em;
+}
+
+.text-neutral-900 {
+  --tw-text-opacity: 1;
+  color: rgb(23 23 23 / var(--tw-text-opacity));
+}
+
+.text-zinc-900 {
+  --tw-text-opacity: 1;
+  color: rgb(24 24 27 / var(--tw-text-opacity));
+}
+
+.text-zinc-600 {
+  --tw-text-opacity: 1;
+  color: rgb(82 82 91 / var(--tw-text-opacity));
+}
+
+.text-zinc-800 {
+  --tw-text-opacity: 1;
+  color: rgb(39 39 42 / var(--tw-text-opacity));
+}
+
+.text-black {
+  --tw-text-opacity: 1;
+  color: rgb(0 0 0 / var(--tw-text-opacity));
+}
+
+.text-transparent {
+  color: transparent;
+}
+
+.text-zinc-700 {
+  --tw-text-opacity: 1;
+  color: rgb(63 63 70 / var(--tw-text-opacity));
+}
+
+.text-zinc-500 {
+  --tw-text-opacity: 1;
+  color: rgb(113 113 122 / var(--tw-text-opacity));
+}
+
+.text-orange-800 {
+  --tw-text-opacity: 1;
+  color: rgb(154 52 18 / var(--tw-text-opacity));
+}
+
+.text-yellow-800 {
+  --tw-text-opacity: 1;
+  color: rgb(133 77 14 / var(--tw-text-opacity));
+}
+
+.text-rose-900 {
+  --tw-text-opacity: 1;
+  color: rgb(136 19 55 / var(--tw-text-opacity));
+}
+
+.text-rose-800 {
+  --tw-text-opacity: 1;
+  color: rgb(159 18 57 / var(--tw-text-opacity));
+}
+
+.text-stone-900 {
+  --tw-text-opacity: 1;
+  color: rgb(28 25 23 / var(--tw-text-opacity));
+}
+
+.text-zinc-400 {
+  --tw-text-opacity: 1;
+  color: rgb(161 161 170 / var(--tw-text-opacity));
+}
+
+.underline {
+  text-decoration-line: underline;
+}
+
+.no-underline {
+  text-decoration-line: none;
+}
+
+.antialiased {
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.opacity-90 {
+  opacity: 0.9;
+}
+
+.opacity-70 {
+  opacity: 0.7;
+}
+
+.shadow-sm {
+  --tw-shadow: 0 1px 2px 0 rgb(0 0 0 / 0.05);
+  --tw-shadow-colored: 0 1px 2px 0 var(--tw-shadow-color);
+  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+}
+
+.shadow {
+  --tw-shadow: 0 1px 3px 0 rgb(0 0 0 / 0.1), 0 1px 2px -1px rgb(0 0 0 / 0.1);
+  --tw-shadow-colored: 0 1px 3px 0 var(--tw-shadow-color), 0 1px 2px -1px var(--tw-shadow-color);
+  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+}
+
+.shadow-\[0_0_2px_0_\#000\] {
+  --tw-shadow: 0 0 2px 0 #000;
+  --tw-shadow-colored: 0 0 2px 0 var(--tw-shadow-color);
+  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+}
+
+.shadow-\[rgba\(0\2c 0\2c 0\2c 0\.2\)_0_-3px_6px\2c rgba\(0\2c 0\2c 0\2c 0\.2\)_0_3px_6px\] {
+  --tw-shadow: rgba(0,0,0,0.2) 0 -3px 6px,rgba(0,0,0,0.2) 0 3px 6px;
+  --tw-shadow-colored: 0 -3px 6px var(--tw-shadow-color), 0 3px 6px var(--tw-shadow-color);
+  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+}
+
+.shadow-black\/20 {
+  --tw-shadow-color: rgb(0 0 0 / 0.2);
+  --tw-shadow: var(--tw-shadow-colored);
+}
+
+.drop-shadow-\[rgba\(0\2c 0\2c 0\2c 0\.2\)_0_-3px_1px\] {
+  --tw-drop-shadow: drop-shadow(rgba(0,0,0,0.2) 0 -3px 1px);
+  filter: var(--tw-blur) var(--tw-brightness) var(--tw-contrast) var(--tw-grayscale) var(--tw-hue-rotate) var(--tw-invert) var(--tw-saturate) var(--tw-sepia) var(--tw-drop-shadow);
+}
+
+.backdrop-blur-sm {
+  --tw-backdrop-blur: blur(4px);
+  -webkit-backdrop-filter: var(--tw-backdrop-blur) var(--tw-backdrop-brightness) var(--tw-backdrop-contrast) var(--tw-backdrop-grayscale) var(--tw-backdrop-hue-rotate) var(--tw-backdrop-invert) var(--tw-backdrop-opacity) var(--tw-backdrop-saturate) var(--tw-backdrop-sepia);
+          backdrop-filter: var(--tw-backdrop-blur) var(--tw-backdrop-brightness) var(--tw-backdrop-contrast) var(--tw-backdrop-grayscale) var(--tw-backdrop-hue-rotate) var(--tw-backdrop-invert) var(--tw-backdrop-opacity) var(--tw-backdrop-saturate) var(--tw-backdrop-sepia);
+}
+
+.backdrop-blur-none {
+  --tw-backdrop-blur: blur(0);
+  -webkit-backdrop-filter: var(--tw-backdrop-blur) var(--tw-backdrop-brightness) var(--tw-backdrop-contrast) var(--tw-backdrop-grayscale) var(--tw-backdrop-hue-rotate) var(--tw-backdrop-invert) var(--tw-backdrop-opacity) var(--tw-backdrop-saturate) var(--tw-backdrop-sepia);
+          backdrop-filter: var(--tw-backdrop-blur) var(--tw-backdrop-brightness) var(--tw-backdrop-contrast) var(--tw-backdrop-grayscale) var(--tw-backdrop-hue-rotate) var(--tw-backdrop-invert) var(--tw-backdrop-opacity) var(--tw-backdrop-saturate) var(--tw-backdrop-sepia);
+}
+
+.transition-all {
+  transition-property: all;
+  transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
+  transition-duration: 150ms;
+}
+
+.transition-colors {
+  transition-property: color, background-color, border-color, text-decoration-color, fill, stroke;
+  transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
+  transition-duration: 150ms;
+}
+
+.transition-transform {
+  transition-property: transform;
+  transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
+  transition-duration: 150ms;
+}
+
+.duration-300 {
+  transition-duration: 300ms;
+}
+
+.fadeIn {
+  opacity: 0;
+  transform: scale(1.2);
+  animation: fadeInAnimation var(--ease-elastic-3) 0.3s;
+  animation-iteration-count: 1;
+  animation-fill-mode: forwards;
+}
+
+@keyframes fadeInAnimation {
+  0% {
+    opacity: 0;
+    transform: scale(2) rotateZ(10deg);
+  }
+
+  100% {
+    opacity: 1;
+    transform: scale(1.2) rotateZ(0);
+  }
+}
+
+.prose {
+  --tw-prose-body: #3f3f46;
+  --tw-prose-headings: #18181b;
+  --tw-prose-lead: #52525b;
+  --tw-prose-links: #18181b;
+  --tw-prose-bold: #18181b;
+  --tw-prose-counters: #71717a;
+  --tw-prose-bullets: #d4d4d8;
+  --tw-prose-hr: #e4e4e7;
+  --tw-prose-quotes: #18181b;
+  --tw-prose-quote-borders: #e4e4e7;
+  --tw-prose-captions: #71717a;
+  --tw-prose-code: #18181b;
+  --tw-prose-pre-code: rgb(238 238 238);
+  --tw-prose-pre-border: rgb(51, 51, 51);
+  --tw-prose-pre-bg: rgb(24 24 24);
+  --tw-prose-th-borders: #d4d4d8;
+  --tw-prose-td-borders: #e4e4e7;
+  --tw-prose-invert-body: #d4d4d8;
+  --tw-prose-invert-headings: #fff;
+  --tw-prose-invert-lead: #a1a1aa;
+  --tw-prose-invert-links: #fff;
+  --tw-prose-invert-bold: #fff;
+  --tw-prose-invert-counters: #a1a1aa;
+  --tw-prose-invert-bullets: #52525b;
+  --tw-prose-invert-hr: #3f3f46;
+  --tw-prose-invert-quotes: #f4f4f5;
+  --tw-prose-invert-quote-borders: #3f3f46;
+  --tw-prose-invert-captions: #a1a1aa;
+  --tw-prose-invert-code: #fff;
+  --tw-prose-invert-pre-code: rgb(238 238 238);
+  --tw-prose-invert-pre-border: rgb(51, 51, 51);
+  --tw-prose-invert-pre-bg: rgb(5, 5, 5);
+  --tw-prose-invert-th-borders: #52525b;
+  --tw-prose-invert-td-borders: #3f3f46;
+}
+
+.dark .prose {
+  --tw-prose-body: var(--tw-prose-invert-body);
+  --tw-prose-headings: var(--tw-prose-invert-headings);
+  --tw-prose-lead: var(--tw-prose-invert-lead);
+  --tw-prose-links: var(--tw-prose-invert-links);
+  --tw-prose-bold: var(--tw-prose-invert-bold);
+  --tw-prose-counters: var(--tw-prose-invert-counters);
+  --tw-prose-bullets: var(--tw-prose-invert-bullets);
+  --tw-prose-hr: var(--tw-prose-invert-hr);
+  --tw-prose-quotes: var(--tw-prose-invert-quotes);
+  --tw-prose-quote-borders: var(--tw-prose-invert-quote-borders);
+  --tw-prose-captions: var(--tw-prose-invert-captions);
+  --tw-prose-code: var(--tw-prose-invert-code);
+  --tw-prose-pre-code: var(--tw-prose-invert-pre-code);
+  --tw-prose-pre-border: var(--tw-prose-invert-pre-border);
+  --tw-prose-pre-bg: var(--tw-prose-invert-pre-bg);
+  --tw-prose-th-borders: var(--tw-prose-invert-th-borders);
+  --tw-prose-td-borders: var(--tw-prose-invert-td-borders);
+}
+
+.prose {
+  font-size: 1rem;
+  line-height: 1.75;
+  color: var(--tw-prose-body);
+}
+
+.prose :where(p):not(:where([class~="not-prose"] *)) {
+  margin-top: 1.25em;
+  margin-bottom: 1.25em;
+}
+
+.prose :where([class~="lead"]):not(:where([class~="not-prose"] *)) {
+  color: var(--tw-prose-lead);
+  font-size: 1.25em;
+  line-height: 1.6;
+  margin-top: 1.2em;
+  margin-bottom: 1.2em;
+}
+
+.prose :where(a):not(:where([class~="not-prose"] *)) {
+  color: var(--tw-prose-links);
+  text-decoration: underline;
+  font-weight: 500;
+}
+
+a.headerlink {
+  margin-left: .25rem;
+  display: inline-block;
+  text-decoration-line: none;
+  opacity: 0;
+  transition-property: opacity;
+  transition-timing-function: cubic-bezier(.4,0,.2,1);
+  transition-duration: .15s;
+}
+
+h2:hover a.headerlink,
+  h3:hover a.headerlink,
+  h4:hover a.headerlink,
+  h5:hover a.headerlink,
+  h6:hover a.headerlink {
+  opacity: 0.5;
+}
+
+.prose :where(strong):not(:where([class~="not-prose"] *)) {
+  color: var(--tw-prose-bold);
+  font-weight: 600;
+}
+
+.prose :where(a strong):not(:where([class~="not-prose"] *)) {
+  color: inherit;
+}
+
+.prose :where(blockquote strong):not(:where([class~="not-prose"] *)) {
+  color: inherit;
+}
+
+.prose :where(thead th strong):not(:where([class~="not-prose"] *)) {
+  color: inherit;
+}
+
+.prose :where(ol):not(:where([class~="not-prose"] *)) {
+  list-style-type: decimal;
+  margin-top: 1.25em;
+  margin-bottom: 1.25em;
+  padding-left: 1.625em;
+}
+
+.prose :where(ol[type="A"]):not(:where([class~="not-prose"] *)) {
+  list-style-type: upper-alpha;
+}
+
+.prose :where(ol[type="a"]):not(:where([class~="not-prose"] *)) {
+  list-style-type: lower-alpha;
+}
+
+.prose :where(ol[type="A" s]):not(:where([class~="not-prose"] *)) {
+  list-style-type: upper-alpha;
+}
+
+.prose :where(ol[type="a" s]):not(:where([class~="not-prose"] *)) {
+  list-style-type: lower-alpha;
+}
+
+.prose :where(ol[type="I"]):not(:where([class~="not-prose"] *)) {
+  list-style-type: upper-roman;
+}
+
+.prose :where(ol[type="i"]):not(:where([class~="not-prose"] *)) {
+  list-style-type: lower-roman;
+}
+
+.prose :where(ol[type="I" s]):not(:where([class~="not-prose"] *)) {
+  list-style-type: upper-roman;
+}
+
+.prose :where(ol[type="i" s]):not(:where([class~="not-prose"] *)) {
+  list-style-type: lower-roman;
+}
+
+.prose :where(ol[type="1"]):not(:where([class~="not-prose"] *)) {
+  list-style-type: decimal;
+}
+
+.prose :where(ul):not(:where([class~="not-prose"] *)) {
+  list-style-type: disc;
+  margin-top: 1.25em;
+  margin-bottom: 1.25em;
+  padding-left: 1.625em;
+}
+
+.prose :where(ol > li):not(:where([class~="not-prose"] *))::marker {
+  font-weight: 400;
+  color: var(--tw-prose-counters);
+}
+
+.prose :where(ul > li):not(:where([class~="not-prose"] *))::marker {
+  color: var(--tw-prose-bullets);
+}
+
+.prose :where(hr):not(:where([class~="not-prose"] *)) {
+  border-color: var(--tw-prose-hr);
+  border-top-width: 1px;
+  margin-top: 3em;
+  margin-bottom: 3em;
+}
+
+.prose :where(blockquote):not(:where([class~="not-prose"] *)) {
+  font-weight: 500;
+  font-style: italic;
+  color: var(--tw-prose-quotes);
+  border-left-width: 0.25rem;
+  border-left-color: var(--tw-prose-quote-borders);
+  quotes: "\201C""\201D""\2018""\2019";
+  margin-top: 1.6em;
+  margin-bottom: 1.6em;
+  padding-left: 1em;
+}
+
+.prose :where(blockquote p:first-of-type):not(:where([class~="not-prose"] *))::before {
+  content: open-quote;
+}
+
+.prose :where(blockquote p:last-of-type):not(:where([class~="not-prose"] *))::after {
+  content: close-quote;
+}
+
+.prose :where(h1):not(:where([class~="not-prose"] *)) {
+  color: var(--tw-prose-headings);
+  font-weight: 800;
+  font-size: 2.25em;
+  margin-top: 0;
+  margin-bottom: 0.8888889em;
+  line-height: 1.1111111;
+}
+
+.prose :where(h1 strong):not(:where([class~="not-prose"] *)) {
+  font-weight: 900;
+  color: inherit;
+}
+
+.prose :where(h2):not(:where([class~="not-prose"] *)) {
+  color: var(--tw-prose-headings);
+  font-weight: 700;
+  font-size: 1.5em;
+  margin-top: 2em;
+  margin-bottom: 1em;
+  line-height: 1.3333333;
+}
+
+.prose :where(h2 strong):not(:where([class~="not-prose"] *)) {
+  font-weight: 800;
+  color: inherit;
+}
+
+.prose :where(h3):not(:where([class~="not-prose"] *)) {
+  color: var(--tw-prose-headings);
+  font-weight: 600;
+  font-size: 1.25em;
+  margin-top: 1.6em;
+  margin-bottom: 0.6em;
+  line-height: 1.6;
+}
+
+.prose :where(h3 strong):not(:where([class~="not-prose"] *)) {
+  font-weight: 700;
+  color: inherit;
+}
+
+.prose :where(h4):not(:where([class~="not-prose"] *)) {
+  color: var(--tw-prose-headings);
+  font-weight: 600;
+  margin-top: 1.5em;
+  margin-bottom: 0.5em;
+  line-height: 1.5;
+}
+
+.prose :where(h4 strong):not(:where([class~="not-prose"] *)) {
+  font-weight: 700;
+  color: inherit;
+}
+
+.prose :where(img):not(:where([class~="not-prose"] *)) {
+  margin-top: 2em;
+  margin-bottom: 2em;
+}
+
+.prose :where(figure > *):not(:where([class~="not-prose"] *)) {
+  margin-top: 0;
+  margin-bottom: 0;
+}
+
+.prose :where(figcaption):not(:where([class~="not-prose"] *)) {
+  color: var(--tw-prose-captions);
+  font-size: 0.875em;
+  line-height: 1.4285714;
+  margin-top: 0.8571429em;
+}
+
+.prose :where(code):not(:where([class~="not-prose"] *)) {
+  color: var(--tw-prose-code);
+  font-weight: 600;
+  font-size: 0.98em;
+  white-space: nowrap;
+  padding-left: 4px;
+  padding-right: 4px;
+}
+
+.prose :where(a code):not(:where([class~="not-prose"] *)) {
+  color: inherit;
+}
+
+.prose :where(h1 code):not(:where([class~="not-prose"] *)) {
+  color: inherit;
+}
+
+.prose :where(h2 code):not(:where([class~="not-prose"] *)) {
+  color: inherit;
+  font-size: 0.875em;
+}
+
+.prose :where(h3 code):not(:where([class~="not-prose"] *)) {
+  color: inherit;
+  font-size: 0.9em;
+}
+
+.prose :where(h4 code):not(:where([class~="not-prose"] *)) {
+  color: inherit;
+}
+
+.prose :where(blockquote code):not(:where([class~="not-prose"] *)) {
+  color: inherit;
+}
+
+.prose :where(thead th code):not(:where([class~="not-prose"] *)) {
+  color: inherit;
+}
+
+.prose :where(pre):not(:where([class~="not-prose"] *)) {
+  color: var(--tw-prose-pre-code);
+  background-color: var(--tw-prose-pre-bg);
+  border: 1px solid rgb(var(--tw-prose-pre-border));
+  overflow-x: auto;
+  font-weight: 400;
+  font-size: 0.98em;
+  font-feature-settings: "kern";
+  line-height: 1.7142857;
+  margin-left: 0;
+  margin-right: 0;
+  margin-top: 0;
+  margin-bottom: 0;
+  border-radius: 0.375rem;
+  padding-top: 0.8571429em;
+  padding-right: 1.1428571em;
+  padding-bottom: 0.8571429em;
+  padding-left: 1.1428571em;
+  white-space: pre;
+  position: relative;
+  z-index: 30;
+}
+
+@media (max-width: 640px) {
+  .prose :where(pre):not(:where([class~="not-prose"] *)) {
+    margin-left: -1rem;
+    margin-right: -1rem;
+    border-left: none;
+    border-right: none;
+    border-radius: 0;
+  }
+}
+
+.prose :where(.filename):not(:where([class~="not-prose"] *)) {
+  display: inline-block;
+  padding: 0.4em 1em 0.8em;
+  font-weight: 500;
+  font-size: 0.8rem;
+  border: 1px solid var(--tw-prose-hr);
+  border-radius: 0.375rem 0.375rem 0 0;
+  border-bottom: none;
+  margin-bottom: -0.375rem;
+  font-family: monospace;
+}
+
+.prose :where(pre a):not(:where([class~="not-prose"] *)) {
+  text-decoration: none;
+}
+
+.prose :where(pre code):not(:where([class~="not-prose"] *)) {
+  background-color: transparent;
+  border-width: 0;
+  border-radius: 0;
+  padding: 0;
+  font-weight: inherit;
+  color: inherit;
+  font-size: inherit;
+  font-family: inherit;
+  line-height: inherit;
+  overflow: auto;
+  overscroll-behavior: contain;
+  scrollbar-width: thin;
+  white-space: pre;
+}
+
+.prose :where(pre code::-webkit-scrollbar) {
+  width: 2px;
+  background-color: ButtonFace;
+}
+
+.prose :where(table):not(:where([class~="not-prose"] *)) {
+  width: 100%;
+  table-layout: auto;
+  text-align: left;
+  margin-top: 2em;
+  margin-bottom: 2em;
+  font-size: 0.875em;
+  line-height: 1.7142857;
+}
+
+.prose :where(thead):not(:where([class~="not-prose"] *)) {
+  border-bottom-width: 1px;
+  border-bottom-color: var(--tw-prose-th-borders);
+}
+
+.prose :where(thead th):not(:where([class~="not-prose"] *)) {
+  color: var(--tw-prose-headings);
+  font-weight: 600;
+  vertical-align: bottom;
+  padding-right: 0.5714286em;
+  padding-bottom: 0.5714286em;
+  padding-left: 0.5714286em;
+}
+
+.prose :where(tbody tr):not(:where([class~="not-prose"] *)) {
+  border-bottom-width: 1px;
+  border-bottom-color: var(--tw-prose-td-borders);
+}
+
+.prose :where(tbody tr:last-child):not(:where([class~="not-prose"] *)) {
+  border-bottom-width: 0;
+}
+
+.prose :where(tbody td):not(:where([class~="not-prose"] *)) {
+  vertical-align: baseline;
+}
+
+.prose :where(tfoot):not(:where([class~="not-prose"] *)) {
+  border-top-width: 1px;
+  border-top-color: var(--tw-prose-th-borders);
+}
+
+.prose :where(tfoot td):not(:where([class~="not-prose"] *)) {
+  vertical-align: top;
+}
+
+.prose :where(video):not(:where([class~="not-prose"] *)) {
+  margin-top: 2em;
+  margin-bottom: 2em;
+}
+
+.prose :where(figure):not(:where([class~="not-prose"] *)) {
+  margin-top: 2em;
+  margin-bottom: 2em;
+}
+
+.prose :where(li):not(:where([class~="not-prose"] *)) {
+  margin-top: 0.5em;
+  margin-bottom: 0.5em;
+}
+
+.prose :where(ol > li):not(:where([class~="not-prose"] *)) {
+  padding-left: 0.375em;
+}
+
+.prose :where(ul > li):not(:where([class~="not-prose"] *)) {
+  padding-left: 0.375em;
+}
+
+.prose :where(.prose > ul > li p):not(:where([class~="not-prose"] *)) {
+  margin-top: 0.75em;
+  margin-bottom: 0.75em;
+}
+
+.prose :where(.prose > ul > li > *:first-child):not(:where([class~="not-prose"] *)) {
+  margin-top: 1.25em;
+}
+
+.prose :where(.prose > ul > li > *:last-child):not(:where([class~="not-prose"] *)) {
+  margin-bottom: 1.25em;
+}
+
+.prose :where(.prose > ol > li > *:first-child):not(:where([class~="not-prose"] *)) {
+  margin-top: 1.25em;
+}
+
+.prose :where(.prose > ol > li > *:last-child):not(:where([class~="not-prose"] *)) {
+  margin-bottom: 1.25em;
+}
+
+.prose :where(ul ul, ul ol, ol ul, ol ol):not(:where([class~="not-prose"] *)) {
+  margin-top: 0.75em;
+  margin-bottom: 0.75em;
+}
+
+.prose :where(hr + *):not(:where([class~="not-prose"] *)) {
+  margin-top: 0;
+}
+
+.prose :where(h2 + *):not(:where([class~="not-prose"] *)) {
+  margin-top: 0;
+}
+
+.prose :where(h3 + *):not(:where([class~="not-prose"] *)) {
+  margin-top: 0;
+}
+
+.prose :where(h4 + *):not(:where([class~="not-prose"] *)) {
+  margin-top: 0;
+}
+
+.prose :where(thead th:first-child):not(:where([class~="not-prose"] *)) {
+  padding-left: 0;
+}
+
+.prose :where(thead th:last-child):not(:where([class~="not-prose"] *)) {
+  padding-right: 0;
+}
+
+.prose :where(tbody td, tfoot td):not(:where([class~="not-prose"] *)) {
+  padding-top: 0.5714286em;
+  padding-right: 0.5714286em;
+  padding-bottom: 0.5714286em;
+  padding-left: 0.5714286em;
+}
+
+.prose :where(tbody td:first-child, tfoot td:first-child):not(:where([class~="not-prose"] *)) {
+  padding-left: 0;
+}
+
+.prose :where(tbody td:last-child, tfoot td:last-child):not(:where([class~="not-prose"] *)) {
+  padding-right: 0;
+}
+
+.prose :where(.prose > :first-child):not(:where([class~="not-prose"] *)) {
+  margin-top: 0;
+}
+
+.prose :where(.prose > :last-child):not(:where([class~="not-prose"] *)) {
+  margin-bottom: 0;
+}
+
+.prose :where(.task-list .task-list):not(:where([class~="not-prose"] *)) {
+  padding-left: 1em;
+}
+
+.prose :where(dl):not(:where([class~="not-prose"] *)) {
+  margin-top: 1.25em;
+  margin-bottom: 1.25em;
+}
+
+.prose :where(dt):not(:where([class~="not-prose"] *)) {
+  font-weight: bold;
+}
+
+.prose :where(dd):not(:where([class~="not-prose"] *)) {
+  padding-left: 1em;
+}
+
+.prose pre code .hll {
+  background-color: #49483e
+}
+
+.prose pre code .c {
+  color: #75715e
+}
+
+/* Comment */
+
+.prose pre code .err {
+  color: #960050;
+  background-color: #1e0010
+}
+
+/* Error */
+
+.prose pre code .k {
+  color: #66d9ef
+}
+
+/* Keyword */
+
+.prose pre code .l {
+  color: #ae81ff
+}
+
+/* Literal */
+
+.prose pre code .n {
+  color: #f8f8f2
+}
+
+/* Name */
+
+.prose pre code .o {
+  color: #f92672
+}
+
+/* Operator */
+
+.prose pre code .p {
+  color: #f8f8f2
+}
+
+/* Punctuation */
+
+.prose pre code .ch {
+  color: #75715e
+}
+
+/* Comment.Hashbang */
+
+.prose pre code .cm {
+  color: #75715e
+}
+
+/* Comment.Multiline */
+
+.prose pre code .cp {
+  color: #75715e
+}
+
+/* Comment.Preproc */
+
+.prose pre code .cpf {
+  color: #75715e
+}
+
+/* Comment.PreprocFile */
+
+.prose pre code .c1 {
+  color: #75715e
+}
+
+/* Comment.Single */
+
+.prose pre code .cs {
+  color: #75715e
+}
+
+/* Comment.Special */
+
+.prose pre code .gd {
+  color: #f92672
+}
+
+/* Generic.Deleted */
+
+.prose pre code .ge {
+  font-style: italic
+}
+
+/* Generic.Emph */
+
+.prose pre code .gi {
+  color: #a6e22e
+}
+
+/* Generic.Inserted */
+
+.prose pre code .gs {
+  font-weight: bold
+}
+
+/* Generic.Strong */
+
+.prose pre code .gu {
+  color: #75715e
+}
+
+/* Generic.Subheading */
+
+.prose pre code .kc {
+  color: #66d9ef
+}
+
+/* Keyword.Constant */
+
+.prose pre code .kd {
+  color: #66d9ef
+}
+
+/* Keyword.Declaration */
+
+.prose pre code .kn {
+  color: #f92672
+}
+
+/* Keyword.Namespace */
+
+.prose pre code .kp {
+  color: #66d9ef
+}
+
+/* Keyword.Pseudo */
+
+.prose pre code .kr {
+  color: #66d9ef
+}
+
+/* Keyword.Reserved */
+
+.prose pre code .kt {
+  color: #66d9ef
+}
+
+/* Keyword.Type */
+
+.prose pre code .ld {
+  color: #e6db74
+}
+
+/* Literal.Date */
+
+.prose pre code .m {
+  color: #ae81ff
+}
+
+/* Literal.Number */
+
+.prose pre code .s {
+  color: #e6db74
+}
+
+/* Literal.String */
+
+.prose pre code .na {
+  color: #a6e22e
+}
+
+/* Name.Attribute */
+
+.prose pre code .nb {
+  color: #f8f8f2
+}
+
+/* Name.Builtin */
+
+.prose pre code .nc {
+  color: #a6e22e
+}
+
+/* Name.Class */
+
+.prose pre code .no {
+  color: #66d9ef
+}
+
+/* Name.Constant */
+
+.prose pre code .nd {
+  color: #a6e22e
+}
+
+/* Name.Decorator */
+
+.prose pre code .ni {
+  color: #f8f8f2
+}
+
+/* Name.Entity */
+
+.prose pre code .ne {
+  color: #a6e22e
+}
+
+/* Name.Exception */
+
+.prose pre code .nf {
+  color: #a6e22e
+}
+
+/* Name.Function */
+
+.prose pre code .nl {
+  color: #f8f8f2
+}
+
+/* Name.Label */
+
+.prose pre code .nn {
+  color: #f8f8f2
+}
+
+/* Name.Namespace */
+
+.prose pre code .nx {
+  color: #a6e22e
+}
+
+/* Name.Other */
+
+.prose pre code .py {
+  color: #f8f8f2
+}
+
+/* Name.Property */
+
+.prose pre code .nt {
+  color: #f92672
+}
+
+/* Name.Tag */
+
+.prose pre code .nv {
+  color: #f8f8f2
+}
+
+/* Name.Variable */
+
+.prose pre code .ow {
+  color: #f92672
+}
+
+/* Operator.Word */
+
+.prose pre code .w {
+  color: #f8f8f2
+}
+
+/* Text.Whitespace */
+
+.prose pre code .mb {
+  color: #ae81ff
+}
+
+/* Literal.Number.Bin */
+
+.prose pre code .mf {
+  color: #ae81ff
+}
+
+/* Literal.Number.Float */
+
+.prose pre code .mh {
+  color: #ae81ff
+}
+
+/* Literal.Number.Hex */
+
+.prose pre code .mi {
+  color: #ae81ff
+}
+
+/* Literal.Number.Integer */
+
+.prose pre code .mo {
+  color: #ae81ff
+}
+
+/* Literal.Number.Oct */
+
+.prose pre code .sa {
+  color: #e6db74
+}
+
+/* Literal.String.Affix */
+
+.prose pre code .sb {
+  color: #e6db74
+}
+
+/* Literal.String.Backtick */
+
+.prose pre code .sc {
+  color: #e6db74
+}
+
+/* Literal.String.Char */
+
+.prose pre code .dl {
+  color: #e6db74
+}
+
+/* Literal.String.Delimiter */
+
+.prose pre code .sd {
+  color: #e6db74
+}
+
+/* Literal.String.Doc */
+
+.prose pre code .s2 {
+  color: #e6db74
+}
+
+/* Literal.String.Double */
+
+.prose pre code .se {
+  color: #ae81ff
+}
+
+/* Literal.String.Escape */
+
+.prose pre code .sh {
+  color: #e6db74
+}
+
+/* Literal.String.Heredoc */
+
+.prose pre code .si {
+  color: #e6db74
+}
+
+/* Literal.String.Interpol */
+
+.prose pre code .sx {
+  color: #e6db74
+}
+
+/* Literal.String.Other */
+
+.prose pre code .sr {
+  color: #e6db74
+}
+
+/* Literal.String.Regex */
+
+.prose pre code .s1 {
+  color: #e6db74
+}
+
+/* Literal.String.Single */
+
+.prose pre code .ss {
+  color: #e6db74
+}
+
+/* Literal.String.Symbol */
+
+.prose pre code .bp {
+  color: #f8f8f2
+}
+
+/* Name.Builtin.Pseudo */
+
+.prose pre code .fm {
+  color: #a6e22e
+}
+
+/* Name.Function.Magic */
+
+.prose pre code .vc {
+  color: #f8f8f2
+}
+
+/* Name.Variable.Class */
+
+.prose pre code .vg {
+  color: #f8f8f2
+}
+
+/* Name.Variable.Global */
+
+.prose pre code .vi {
+  color: #f8f8f2
+}
+
+/* Name.Variable.Instance */
+
+.prose pre code .vm {
+  color: #f8f8f2
+}
+
+/* Name.Variable.Magic */
+
+.prose pre code .il {
+  color: #ae81ff
+}
+
+/* Literal.Number.Integer.Long */
+
+.last\:border-r:last-child {
+  border-right-width: 1px;
+}
+
+.open\:block[open] {
+  display: block;
+}
+
+.hover\:border-zinc-300:hover {
+  --tw-border-opacity: 1;
+  border-color: rgb(212 212 216 / var(--tw-border-opacity));
+}
+
+.hover\:bg-zinc-100:hover {
+  --tw-bg-opacity: 1;
+  background-color: rgb(244 244 245 / var(--tw-bg-opacity));
+}
+
+.hover\:from-lime-400:hover {
+  --tw-gradient-from: #a3e635;
+  --tw-gradient-to: rgb(163 230 53 / 0);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to);
+}
+
+.hover\:to-lime-400:hover {
+  --tw-gradient-to: #a3e635;
+}
+
+.hover\:text-zinc-900:hover {
+  --tw-text-opacity: 1;
+  color: rgb(24 24 27 / var(--tw-text-opacity));
+}
+
+.hover\:text-black:hover {
+  --tw-text-opacity: 1;
+  color: rgb(0 0 0 / var(--tw-text-opacity));
+}
+
+.hover\:opacity-100:hover {
+  opacity: 1;
+}
+
+.hover\:shadow-sm:hover {
+  --tw-shadow: 0 1px 2px 0 rgb(0 0 0 / 0.05);
+  --tw-shadow-colored: 0 1px 2px 0 var(--tw-shadow-color);
+  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+}
+
+.focus\:outline-offset-1:focus {
+  outline-offset: 1px;
+}
+
+.active\:border-zinc-400:active {
+  --tw-border-opacity: 1;
+  border-color: rgb(161 161 170 / var(--tw-border-opacity));
+}
+
+.disabled\:cursor-default:disabled {
+  cursor: default;
+}
+
+.disabled\:outline-none:disabled {
+  outline: 2px solid transparent;
+  outline-offset: 2px;
+}
+
+.group[open] .group-open\:-rotate-90 {
+  --tw-rotate: -90deg;
+  transform: translate(var(--tw-translate-x), var(--tw-translate-y)) rotate(var(--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y)) scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y));
+}
+
+.group[open] .group-open\:bg-black\/20 {
+  background-color: rgb(0 0 0 / 0.2);
+}
+
+.group[open] .group-open\:backdrop-blur-sm {
+  --tw-backdrop-blur: blur(4px);
+  -webkit-backdrop-filter: var(--tw-backdrop-blur) var(--tw-backdrop-brightness) var(--tw-backdrop-contrast) var(--tw-backdrop-grayscale) var(--tw-backdrop-hue-rotate) var(--tw-backdrop-invert) var(--tw-backdrop-opacity) var(--tw-backdrop-saturate) var(--tw-backdrop-sepia);
+          backdrop-filter: var(--tw-backdrop-blur) var(--tw-backdrop-brightness) var(--tw-backdrop-contrast) var(--tw-backdrop-grayscale) var(--tw-backdrop-hue-rotate) var(--tw-backdrop-invert) var(--tw-backdrop-opacity) var(--tw-backdrop-saturate) var(--tw-backdrop-sepia);
+}
+
+.group:hover .group-hover\:block {
+  display: block;
+}
+
+.group:hover .group-hover\:fill-zinc-800 {
+  fill: #27272a;
+}
+
+.group:hover .group-hover\:fill-zinc-500 {
+  fill: #71717a;
+}
+
+.group:hover .group-hover\:stroke-zinc-800 {
+  stroke: #27272a;
+}
+
+.group:hover .group-hover\:text-zinc-600 {
+  --tw-text-opacity: 1;
+  color: rgb(82 82 91 / var(--tw-text-opacity));
+}
+
+.group:hover .group-hover\:text-zinc-900 {
+  --tw-text-opacity: 1;
+  color: rgb(24 24 27 / var(--tw-text-opacity));
+}
+
+.group:focus .group-focus\:block {
+  display: block;
+}
+
+.group:focus-visible .group-focus-visible\:fill-zinc-800 {
+  fill: #27272a;
+}
+
+.group:focus-visible .group-focus-visible\:stroke-zinc-800 {
+  stroke: #27272a;
+}
+
+.group.active .group-\[\.active\]\:border-zinc-200 {
+  --tw-border-opacity: 1;
+  border-color: rgb(228 228 231 / var(--tw-border-opacity));
+}
+
+.group.active .group-\[\.active\]\:bg-zinc-100 {
+  --tw-bg-opacity: 1;
+  background-color: rgb(244 244 245 / var(--tw-bg-opacity));
+}
+
+.group.active .group-\[\.active\]\:font-medium {
+  font-weight: 500;
+}
+
+.group.active .group-\[\.active\]\:text-zinc-800 {
+  --tw-text-opacity: 1;
+  color: rgb(39 39 42 / var(--tw-text-opacity));
+}
+
+@media (prefers-reduced-motion: no-preference) {
+  .motion-safe\:transition-transform {
+    transition-property: transform;
+    transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
+    transition-duration: 150ms;
+  }
+
+  .motion-safe\:transition-\[transform\2c opacity\] {
+    transition-property: transform,opacity;
+    transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
+    transition-duration: 150ms;
+  }
+
+  .motion-safe\:duration-500 {
+    transition-duration: 500ms;
+  }
+
+  .motion-safe\:duration-300 {
+    transition-duration: 300ms;
+  }
+
+  .motion-safe\:ease-elastic-3 {
+    transition-timing-function: var(--ease-elastic-3);
+  }
+
+  .motion-safe\:ease-elastic-4 {
+    transition-timing-function: var(--ease-elastic-4);
+  }
+
+  .motion-safe\:ease-out-5 {
+    transition-timing-function: var(--ease-out-5);
+  }
+}
+
+.dark .dark\:translate-x-\[-7px\] {
+  --tw-translate-x: -7px;
+  transform: translate(var(--tw-translate-x), var(--tw-translate-y)) rotate(var(--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y)) scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y));
+}
+
+.dark .dark\:rotate-\[-25deg\] {
+  --tw-rotate: -25deg;
+  transform: translate(var(--tw-translate-x), var(--tw-translate-y)) rotate(var(--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y)) scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y));
+}
+
+.dark .dark\:scale-\[1\.75\] {
+  --tw-scale-x: 1.75;
+  --tw-scale-y: 1.75;
+  transform: translate(var(--tw-translate-x), var(--tw-translate-y)) rotate(var(--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y)) scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y));
+}
+
+.dark .dark\:border-zinc-600 {
+  --tw-border-opacity: 1;
+  border-color: rgb(82 82 91 / var(--tw-border-opacity));
+}
+
+.dark .dark\:border-neutral-600 {
+  --tw-border-opacity: 1;
+  border-color: rgb(82 82 82 / var(--tw-border-opacity));
+}
+
+.dark .dark\:border-stone-800 {
+  --tw-border-opacity: 1;
+  border-color: rgb(41 37 36 / var(--tw-border-opacity));
+}
+
+.dark .dark\:border-zinc-700\/50 {
+  border-color: rgb(63 63 70 / 0.5);
+}
+
+.dark .dark\:border-black {
+  --tw-border-opacity: 1;
+  border-color: rgb(0 0 0 / var(--tw-border-opacity));
+}
+
+.dark .dark\:border-b-black {
+  --tw-border-opacity: 1;
+  border-bottom-color: rgb(0 0 0 / var(--tw-border-opacity));
+}
+
+.dark .dark\:bg-neutral-900 {
+  --tw-bg-opacity: 1;
+  background-color: rgb(23 23 23 / var(--tw-bg-opacity));
+}
+
+.dark .dark\:bg-zinc-800\/60 {
+  background-color: rgb(39 39 42 / 0.6);
+}
+
+.dark .dark\:bg-zinc-600\/10 {
+  background-color: rgb(82 82 91 / 0.1);
+}
+
+.dark .dark\:bg-stone-800 {
+  --tw-bg-opacity: 1;
+  background-color: rgb(41 37 36 / var(--tw-bg-opacity));
+}
+
+.dark .dark\:bg-white\/0 {
+  background-color: rgb(255 255 255 / 0);
+}
+
+.dark .dark\:bg-zinc-900 {
+  --tw-bg-opacity: 1;
+  background-color: rgb(24 24 27 / var(--tw-bg-opacity));
+}
+
+.dark .dark\:bg-black {
+  --tw-bg-opacity: 1;
+  background-color: rgb(0 0 0 / var(--tw-bg-opacity));
+}
+
+.dark .dark\:from-black {
+  --tw-gradient-from: #000;
+  --tw-gradient-to: rgb(0 0 0 / 0);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to);
+}
+
+.dark .dark\:to-stone-900 {
+  --tw-gradient-to: #1c1917;
+}
+
+.dark .dark\:fill-zinc-200 {
+  fill: #e4e4e7;
+}
+
+.dark .dark\:stroke-zinc-200 {
+  stroke: #e4e4e7;
+}
+
+.dark .dark\:text-white {
+  --tw-text-opacity: 1;
+  color: rgb(255 255 255 / var(--tw-text-opacity));
+}
+
+.dark .dark\:text-zinc-100 {
+  --tw-text-opacity: 1;
+  color: rgb(244 244 245 / var(--tw-text-opacity));
+}
+
+.dark .dark\:text-zinc-300 {
+  --tw-text-opacity: 1;
+  color: rgb(212 212 216 / var(--tw-text-opacity));
+}
+
+.dark .dark\:text-zinc-200 {
+  --tw-text-opacity: 1;
+  color: rgb(228 228 231 / var(--tw-text-opacity));
+}
+
+.dark .dark\:text-neutral-100 {
+  --tw-text-opacity: 1;
+  color: rgb(245 245 245 / var(--tw-text-opacity));
+}
+
+.dark .dark\:text-zinc-400 {
+  --tw-text-opacity: 1;
+  color: rgb(161 161 170 / var(--tw-text-opacity));
+}
+
+.dark .dark\:text-inherit {
+  color: inherit;
+}
+
+.dark .dark\:text-zinc-500 {
+  --tw-text-opacity: 1;
+  color: rgb(113 113 122 / var(--tw-text-opacity));
+}
+
+.dark .dark\:opacity-0 {
+  opacity: 0;
+}
+
+.dark .dark\:invert {
+  --tw-invert: invert(100%);
+  filter: var(--tw-blur) var(--tw-brightness) var(--tw-contrast) var(--tw-grayscale) var(--tw-hue-rotate) var(--tw-invert) var(--tw-saturate) var(--tw-sepia) var(--tw-drop-shadow);
+}
+
+.dark .dark\:hover\:border-zinc-500:hover {
+  --tw-border-opacity: 1;
+  border-color: rgb(113 113 122 / var(--tw-border-opacity));
+}
+
+.dark .dark\:hover\:border-zinc-400:hover {
+  --tw-border-opacity: 1;
+  border-color: rgb(161 161 170 / var(--tw-border-opacity));
+}
+
+.dark .dark\:hover\:bg-zinc-900:hover {
+  --tw-bg-opacity: 1;
+  background-color: rgb(24 24 27 / var(--tw-bg-opacity));
+}
+
+.dark .dark\:hover\:text-white:hover {
+  --tw-text-opacity: 1;
+  color: rgb(255 255 255 / var(--tw-text-opacity));
+}
+
+.dark .dark\:hover\:text-zinc-100:hover {
+  --tw-text-opacity: 1;
+  color: rgb(244 244 245 / var(--tw-text-opacity));
+}
+
+.dark .dark\:active\:border-zinc-400:active {
+  --tw-border-opacity: 1;
+  border-color: rgb(161 161 170 / var(--tw-border-opacity));
+}
+
+.group[open] .dark .group-open\:dark\:bg-white\/20 {
+  background-color: rgb(255 255 255 / 0.2);
+}
+
+.dark .group:hover .dark\:group-hover\:fill-zinc-100 {
+  fill: #f4f4f5;
+}
+
+.dark .group:hover .dark\:group-hover\:stroke-zinc-100 {
+  stroke: #f4f4f5;
+}
+
+.dark .group:hover .dark\:group-hover\:text-zinc-400 {
+  --tw-text-opacity: 1;
+  color: rgb(161 161 170 / var(--tw-text-opacity));
+}
+
+.dark .group:hover .dark\:group-hover\:text-white {
+  --tw-text-opacity: 1;
+  color: rgb(255 255 255 / var(--tw-text-opacity));
+}
+
+.dark .group:hover .dark\:group-hover\:text-zinc-300 {
+  --tw-text-opacity: 1;
+  color: rgb(212 212 216 / var(--tw-text-opacity));
+}
+
+.dark .group:focus-visible .dark\:group-focus-visible\:fill-zinc-100 {
+  fill: #f4f4f5;
+}
+
+.dark .group:focus-visible .dark\:group-focus-visible\:stroke-zinc-100 {
+  stroke: #f4f4f5;
+}
+
+.group.active .dark .group-\[\.active\]\:dark\:text-zinc-300 {
+  --tw-text-opacity: 1;
+  color: rgb(212 212 216 / var(--tw-text-opacity));
+}
+
+@media (prefers-reduced-motion: no-preference) {
+  .dark .dark\:motion-safe\:delay-300 {
+    transition-delay: 300ms;
+  }
+
+  .dark .dark\:motion-safe\:duration-\[250ms\] {
+    transition-duration: 250ms;
+  }
+
+  .dark .dark\:motion-safe\:duration-150 {
+    transition-duration: 150ms;
+  }
+
+  .dark .dark\:motion-safe\:ease-3 {
+    transition-timing-function: var(--ease-3);
+  }
+}
+
+@media (min-width: 640px) {
+  .sm\:m-0 {
+    margin: 0px;
+  }
+
+  .sm\:mx-0 {
+    margin-left: 0px;
+    margin-right: 0px;
+  }
+
+  .sm\:mb-10 {
+    margin-bottom: 2.5rem;
+  }
+
+  .sm\:mt-0 {
+    margin-top: 0px;
+  }
+
+  .sm\:mb-0 {
+    margin-bottom: 0px;
+  }
+
+  .sm\:ml-0 {
+    margin-left: 0px;
+  }
+
+  .sm\:ml-6 {
+    margin-left: 1.5rem;
+  }
+
+  .sm\:mr-0 {
+    margin-right: 0px;
+  }
+
+  .sm\:block {
+    display: block;
+  }
+
+  .sm\:flex {
+    display: flex;
+  }
+
+  .sm\:items-center {
+    align-items: center;
+  }
+
+  .sm\:rounded {
+    border-radius: 0.25rem;
+  }
+
+  .sm\:border-x {
+    border-left-width: 1px;
+    border-right-width: 1px;
+  }
+
+  .sm\:border-l {
+    border-left-width: 1px;
+  }
+
+  .sm\:px-6 {
+    padding-left: 1.5rem;
+    padding-right: 1.5rem;
+  }
+
+  .sm\:px-0 {
+    padding-left: 0px;
+    padding-right: 0px;
+  }
+
+  .sm\:py-12 {
+    padding-top: 3rem;
+    padding-bottom: 3rem;
+  }
+
+  .sm\:px-7 {
+    padding-left: 1.75rem;
+    padding-right: 1.75rem;
+  }
+
+  .sm\:py-6 {
+    padding-top: 1.5rem;
+    padding-bottom: 1.5rem;
+  }
+
+  .sm\:pt-10 {
+    padding-top: 2.5rem;
+  }
+
+  .sm\:pb-12 {
+    padding-bottom: 3rem;
+  }
+
+  .sm\:pr-2 {
+    padding-right: 0.5rem;
+  }
+
+  .sm\:pl-2 {
+    padding-left: 0.5rem;
+  }
+
+  .sm\:text-3xl {
+    font-size: 1.875rem;
+    line-height: 2.25rem;
+  }
+
+  .dark .dark\:sm\:border-l-zinc-600 {
+    --tw-border-opacity: 1;
+    border-left-color: rgb(82 82 91 / var(--tw-border-opacity));
+  }
+}
+
+@media (min-width: 768px) {
+  .md\:flex {
+    display: flex;
+  }
+
+  .md\:h-\[500px\] {
+    height: 500px;
+  }
+
+  .md\:h-40 {
+    height: 10rem;
+  }
+
+  .md\:w-1\/2 {
+    width: 50%;
+  }
+
+  .md\:grid-cols-2 {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .md\:items-stretch {
+    align-items: stretch;
+  }
+
+  .md\:whitespace-nowrap {
+    white-space: nowrap;
+  }
+
+  .md\:text-6xl {
+    font-size: 3.75rem;
+    line-height: 1;
+  }
+
+  .md\:text-5xl {
+    font-size: 3rem;
+    line-height: 1;
+  }
+
+  .md\:text-4xl {
+    font-size: 2.25rem;
+    line-height: 2.5rem;
+  }
+
+  .md\:leading-tight {
+    line-height: 1.25;
+  }
+}
+
+@media (min-width: 1024px) {
+  .lg\:mr-9 {
+    margin-right: 2.25rem;
+  }
+
+  .lg\:block {
+    display: block;
+  }
+
+  .lg\:flex {
+    display: flex;
+  }
+
+  .lg\:hidden {
+    display: none;
+  }
+
+  .lg\:max-w-6xl {
+    max-width: 72rem;
+  }
+
+  .lg\:justify-center {
+    justify-content: center;
+  }
+
+  .lg\:px-8 {
+    padding-left: 2rem;
+    padding-right: 2rem;
+  }
+
+  .lg\:pl-\[440px\] {
+    padding-left: 440px;
+  }
+
+  .lg\:pl-8 {
+    padding-left: 2rem;
+  }
+
+  .lg\:text-center {
+    text-align: center;
+  }
+
+  .lg\:text-7xl {
+    font-size: 4.5rem;
+    line-height: 1;
+  }
+
+  .open\:lg\:hidden[open] {
+    display: none;
+  }
+
+  .dark .lg\:dark\:block {
+    display: block;
+  }
+
+  .dark .lg\:dark\:hidden {
+    display: none;
+  }
+}
+
+@media (min-width: 1280px) {
+  .xl\:h-52 {
+    height: 13rem;
+  }
+
+  .xl\:max-w-screen-xl {
+    max-width: 1280px;
+  }
+
+  .xl\:grid-cols-4 {
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+  }
+
+  .xl\:items-start {
+    align-items: flex-start;
+  }
+
+  .xl\:py-6 {
+    padding-top: 1.5rem;
+    padding-bottom: 1.5rem;
+  }
+}
+
+@media (min-width: 1536px) {
+  .\32xl\:mx-10 {
+    margin-left: 2.5rem;
+    margin-right: 2.5rem;
+  }
+
+  .\32xl\:block {
+    display: block;
+  }
+
+  .\32xl\:text-base {
+    font-size: 1rem;
+    line-height: 1.5rem;
+  }
+}
+
+@media (min-height: 768px) {
+  .tall\:sticky {
+    position: sticky;
+  }
+
+  .tall\:top-0 {
+    top: 0px;
+  }
+
+  .tall\:top-16 {
+    top: 4rem;
+  }
+}
+
+.\[\&_\.highlight\]\:h-full .highlight {
+  height: 100%;
+}
+
+.\[\&_pre\]\:h-full pre {
+  height: 100%;
+}
+
+.\[\&_code\]\:h-full code {
+  height: 100%;
+}
+
+.\[\&_a\.active\]\:pl-2 a.active {
+  padding-left: 0.5rem;
+}
+
+.\[\&_a\.active\]\:text-zinc-700 a.active {
+  --tw-text-opacity: 1;
+  color: rgb(63 63 70 / var(--tw-text-opacity));
+}
+
+.dark .\[\&_a\.active\]\:dark\:text-zinc-400 a.active {
+  --tw-text-opacity: 1;
+  color: rgb(161 161 170 / var(--tw-text-opacity));
+}
+
+.\[\&_a\:hover\]\:border-zinc-700 a:hover {
+  --tw-border-opacity: 1;
+  border-color: rgb(63 63 70 / var(--tw-border-opacity));
+}
+
+.\[\&_a\:hover\]\:text-black a:hover {
+  --tw-text-opacity: 1;
+  color: rgb(0 0 0 / var(--tw-text-opacity));
+}
+
+.\[\&_a\:hover\]\:text-white a:hover {
+  --tw-text-opacity: 1;
+  color: rgb(255 255 255 / var(--tw-text-opacity));
+}
+
+.dark .\[\&_a\:hover\]\:dark\:border-zinc-400 a:hover {
+  --tw-border-opacity: 1;
+  border-color: rgb(161 161 170 / var(--tw-border-opacity));
+}
+
+.dark .\[\&_a\:hover\]\:dark\:text-zinc-100 a:hover {
+  --tw-text-opacity: 1;
+  color: rgb(244 244 245 / var(--tw-text-opacity));
+}
+
+.\[\&_a\]\:flex a {
+  display: flex;
+}
+
+.\[\&_a\]\:h-8 a {
+  height: 2rem;
+}
+
+.\[\&_a\]\:w-full a {
+  width: 100%;
+}
+
+.\[\&_a\]\:items-center a {
+  align-items: center;
+}
+
+.\[\&_a\]\:border-l a {
+  border-left-width: 1px;
+}
+
+.\[\&_a\]\:border-transparent a {
+  border-color: transparent;
+}
+
+.\[\&_a\]\:pb-1 a {
+  padding-bottom: 0.25rem;
+}
+
+.\[\&_a\]\:pl-3 a {
+  padding-left: 0.75rem;
+}
+
+.\[\&_a\]\:pr-2 a {
+  padding-right: 0.5rem;
+}
+
+.\[\&_a\]\:pt-2 a {
+  padding-top: 0.5rem;
+}
+
+.\[\&_a\]\:pl-6 a {
+  padding-left: 1.5rem;
+}
+
+.\[\&_a\]\:pr-4 a {
+  padding-right: 1rem;
+}
+
+.\[\&_a\]\:text-zinc-600 a {
+  --tw-text-opacity: 1;
+  color: rgb(82 82 91 / var(--tw-text-opacity));
+}
+
+.dark .\[\&_a\]\:dark\:text-zinc-500 a {
+  --tw-text-opacity: 1;
+  color: rgb(113 113 122 / var(--tw-text-opacity));
+}
+
+.\[\&\.\.ui-disabled\]\:z-0..ui-disabled {
+  z-index: 0;
+}
+
+.\[\&\.\.ui-disabled\]\:cursor-not-allowed..ui-disabled {
+  cursor: not-allowed;
+}
+
+.\[\&\.\.ui-disabled\]\:bg-zinc-300..ui-disabled {
+  --tw-bg-opacity: 1;
+  background-color: rgb(212 212 216 / var(--tw-bg-opacity));
+}
+
+.\[\&\.\.ui-disabled\]\:text-zinc-400..ui-disabled {
+  --tw-text-opacity: 1;
+  color: rgb(161 161 170 / var(--tw-text-opacity));
+}
+
+.\[\&\.ui-selected\]\:z-20.ui-selected {
+  z-index: 20;
+}
+
+.\[\&\.ui-selected\]\:border-b-0.ui-selected {
+  border-bottom-width: 0px;
+}
+
+.\[\&\.ui-selected\]\:border-t-2.ui-selected {
+  border-top-width: 2px;
+}
+
+.\[\&\.ui-selected\]\:bg-\[\#181818\].ui-selected {
+  --tw-bg-opacity: 1;
+  background-color: rgb(24 24 24 / var(--tw-bg-opacity));
+}
+
+.\[\&\.ui-selected\]\:text-white.ui-selected {
+  --tw-text-opacity: 1;
+  color: rgb(255 255 255 / var(--tw-text-opacity));
+}
+
+.\[\&\.ui-hidden\]\:hidden.ui-hidden {
+  display: none;
+}
+
+.\[\&_div\.highlight\]\:m-0 div.highlight {
+  margin: 0px;
+}
+
+.\[\&_div\.highlight\]\:border-0 div.highlight {
+  border-width: 0px;
+}
+
+.\[\&_a\:first-child\]\:rounded-t-md a:first-child {
+  border-top-left-radius: 0.375rem;
+  border-top-right-radius: 0.375rem;
+}
+
+.\[\&_a\:last-child\]\:rounded-b-md a:last-child {
+  border-bottom-right-radius: 0.375rem;
+  border-bottom-left-radius: 0.375rem;
+}
+
+.\[\&_a\.active\:before\]\:pr-1 a.active:before {
+  padding-right: 0.25rem;
+}
+
+.\[\&_a\.active\:before\]\:content-\[\'\2713\'\] a.active:before {
+  --tw-content: '✓';
+  content: var(--tw-content);
+}

--- a/src/jinjax/component.py
+++ b/src/jinjax/component.py
@@ -106,8 +106,12 @@ class Component:
     def parse_files_expr(self, expr: str) -> "list[str]":
         files = []
         for url in RX_COMMA.split(expr):
-            url = url.strip("\"'/")
-            if url:
+            url = url.strip("\"'").rstrip("/")
+            if not url:
+                continue
+            if url.startswith(("/", "http://", "https://")):
+                files.append(url)
+            else:
                 files.append(f"{self.url_prefix}{url}")
         return files
 

--- a/tests/test_component.py
+++ b/tests/test_component.py
@@ -112,7 +112,7 @@ def test_comma_in_default_value():
 def test_load_assets():
     com = Component(
         name="Test.jinja",
-        source='{#css a.css, "b.css", /c.css -#}\n{#js a.js, b.js, c.js -#}\n',
+        source='{#css a.css, "b.css", c.css -#}\n{#js a.js, b.js, c.js -#}\n',
         url_prefix="/static/"
     )
     assert com.css == ["/static/a.css", "/static/b.css", "/static/c.css"]
@@ -217,3 +217,15 @@ def test_linejump_in_args_decl():
         "lorem": 4,
         "ipsum": "bar",
     }
+
+
+def test_global_assets():
+    com = Component(
+        name="Test.jinja",
+        source="""
+        {#css a.css, /static/shared/b.css, http://example.com/cdn.css #}
+        {#js "http://example.com/cdn.js", a.js, /static/shared/b.js #}
+        """,
+    )
+    assert com.css == ["a.css", "/static/shared/b.css", "http://example.com/cdn.css"]
+    assert com.js == ["http://example.com/cdn.js", "a.js", "/static/shared/b.js"]


### PR DESCRIPTION
Before, any URL declared in the metadata ({#css ... #} and {#js ... #}) was prepended with the component prefix:

```
{#css /shared/foo.css, http://example.com/cdn.css #}` 
```
became

```html
<link rel="stylesheet" href="/static/components/shared/foo.css">
<link rel="stylesheet" href="/static/components/http://example.com/cdn).css">
```

People were even adding their static folder to be able to import their global assets.

This PR fixes this by **not** adding a prefix to the URLs if it starts with "/", "http://", or "https://".

