### PR TITLE
Add a components cache

### DIFF
--- a/benchmark/Card.jinja
+++ b/benchmark/Card.jinja
@@ -1,0 +1,4 @@
+<section class="card">
+{{ content }}
+<CloseBtn disabled />
+</section>

--- a/benchmark/CloseBtn.jinja
+++ b/benchmark/CloseBtn.jinja
@@ -1,0 +1,2 @@
+{#def disabled=False -#}
+<button type="button"{{ " disabled" if disabled else "" }}>&times;</button>

--- a/benchmark/Greeting.jinja
+++ b/benchmark/Greeting.jinja
@@ -1,0 +1,2 @@
+{#def message #}
+<div class="greeting [&_a]:flex">{{ message }}</div>

--- a/benchmark/Layout.jinja
+++ b/benchmark/Layout.jinja
@@ -1,0 +1,13 @@
+{#def title #}
+
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta content="width=device-width, initial-scale=1, shrink-to-fit=no" name="viewport" />
+<title>{{ title }}</title>
+</head>
+<body>
+{{ content }}
+</body>
+</html>

--- a/benchmark/Real.jinja
+++ b/benchmark/Real.jinja
@@ -1,0 +1,8 @@
+{#def message #}
+
+<Layout title="Hello">
+<Card>
+<Greeting message={message} />
+<button type="button">Close</button>
+</Card>
+</Layout>

--- a/benchmark/Simple.jinja
+++ b/benchmark/Simple.jinja
@@ -1,0 +1,16 @@
+{#def message #}
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta content="width=device-width, initial-scale=1, shrink-to-fit=no" name="viewport" />
+<title>{{ message }}</title>
+</head>
+<body>
+<section class="card">
+<div class="greeting [&_a]:flex">{{ message }}</div>
+<button type="button">Close</button>
+<button type="button" disabled>&times;</button>
+</section>
+</body>
+</html>

--- a/benchmark/benchmark.py
+++ b/benchmark/benchmark.py
@@ -1,0 +1,93 @@
+import timeit
+from pathlib import Path
+
+from fastapi.templating import Jinja2Templates
+from jinja2 import Environment, FileSystemLoader
+from jinjax import Catalog
+
+
+here = Path(__file__).parent
+number = 10_000
+
+catalog = Catalog()
+catalog.add_folder(here)
+
+env = Environment(loader=FileSystemLoader(here))
+
+templates = Jinja2Templates(directory=here)
+
+
+def render_jinjax_simple():
+    """simple case"""
+    catalog.render("Simple", message="Hey there")
+
+
+def render_jinjax_real():
+    """realistic case"""
+    catalog.render("Real", message="Hey there")
+
+
+def render_jinja():
+    env.get_template("hello.html").render(message="Hey there")
+
+
+def render_fastapi():
+    templates.TemplateResponse("hello.html", {"request": None, "message": "Hey there"})
+
+
+def benchmark_no_cache(func):
+    print(f"NO CACHE: {number:_} renders of {func.__doc__}...\n")
+    catalog.use_cache = False
+    benchmark(func)
+
+
+def benchmark_auto_reload(func):
+    print(f"CACHE, AUTO-RELOAD: {number:_} renders of {func.__doc__}...\n")
+    catalog.use_cache = True
+    catalog.auto_reload = True
+    benchmark(func)
+
+
+def benchmark_no_auto_reload(func):
+    print(f"CACHE, NO AUTO-RELOAD: {number:_} renders of {func.__doc__}...\n")
+    catalog.use_cache = True
+    catalog.auto_reload = False
+    benchmark(func)
+
+
+def benchmark(func):
+    time_jinjax = timeit.timeit(func, number=number)
+    print_line("JinjaX", time_jinjax)
+    print(f"{time_jinjax / time_jinja:.1f} times Jinja")
+    print(f"{time_jinjax / time_fastapi:.1f} times FastApi")
+
+
+def print_line(name, time):
+    print(f"{name}: {(time / number):.12f}s per render ({(1_000_000 * time / number):.0f}µs), {time:.1f}s total")
+
+
+def print_separator():
+    print()
+    print("-" * 60)
+
+
+if __name__ == "__main__":
+    print(f"Benchmarking...\n")
+    time_jinja = timeit.timeit(render_jinja, number=number)
+    time_fastapi = timeit.timeit(render_fastapi, number=number)
+
+    print_line("Jinja", time_jinja)
+    print_line("FastApi", time_fastapi)
+    print_separator()
+    benchmark_no_cache(render_jinjax_simple)
+    print_separator()
+    benchmark_auto_reload(render_jinjax_simple)
+    print_separator()
+    benchmark_no_auto_reload(render_jinjax_simple)
+    print_separator()
+    benchmark_no_cache(render_jinjax_real)
+    print_separator()
+    benchmark_auto_reload(render_jinjax_real)
+    print_separator()
+    benchmark_no_auto_reload(render_jinjax_real)
+    print()

--- a/benchmark/hello.html
+++ b/benchmark/hello.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta content="width=device-width, initial-scale=1, shrink-to-fit=no" name="viewport" />
+<title>{{ message }}</title>
+</head>
+<body>
+<section class="card">
+<div class="greeting [&_a]:flex">{{ message }}</div>
+<button type="button">Close</button>
+<button type="button" disabled>&times;</button>
+</section>
+</body>
+</html>

--- a/benchmark/profile.py
+++ b/benchmark/profile.py
@@ -1,0 +1,29 @@
+from pathlib import Path
+
+from jinjax import Catalog, Component
+from line_profiler import LineProfiler
+
+
+HERE = Path(__file__).parent
+
+catalog = Catalog()
+catalog.add_folder(HERE)
+
+profile = LineProfiler(
+    Catalog.irender,
+    Catalog._get_from_file,
+    Component.__init__,
+    Component.from_cache,
+    Component.filter_args,
+    Component.render,
+)
+
+def render_jinjax():
+    for _ in range(1000):
+        catalog.render("Hello", message="Hey there")
+
+
+if __name__ == "__main__":
+    print("Profiling...")
+    profile.runcall(render_jinjax)
+    profile.print_stats()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -18,6 +18,6 @@ def folder_t(tmp_path):
 
 @pytest.fixture()
 def catalog(folder):
-    catalog = jinjax.Catalog()
+    catalog = jinjax.Catalog(auto_reload=False)
     catalog.add_folder(folder)
     return catalog


### PR DESCRIPTION
Addresses #23. It works by storing in memory the components metadata (including the last-modified timestamp) and the result of Jinja's `get_template(tmpl_name)`.

Because the template could have been updated after being cached, it tests if the file still exists and if its modified time is the same as the one stored. This check takes time and is not needed in production, so it can be avoided by setting the new catalog argument `auto_reload` to `False`.

The cache can be also deactivated by setting the new catalog argument `use_cache` to `False`.

This are the results of the benchmark:

```
Jinja: 0.000012999120s per render (13µs), 0.1_s total
FastApi: 0.000021882281s per render (22µs), 0.2s total

------------------------------------------------------------
NO CACHE: 10_000 renders of simple case...

JinjaX: 0.000115001536s per render (115µs), 1.2s total
8.8 times Jinja
5.3 times FastApi

------------------------------------------------------------
CACHE, AUTO-RELOAD: 10_000 renders of simple case...

JinjaX: 0.000024344903s per render (24µs), 0.2s total
1.9 times Jinja
1.1 times FastApi

------------------------------------------------------------
CACHE, NO AUTO-RELOAD: 10_000 renders of simple case...

JinjaX: 0.000017458029s per render (17µs), 0.2s total
1.3 times Jinja
0.8 times FastApi

------------------------------------------------------------
NO CACHE: 10_000 renders of realistic case...

JinjaX: 0.000631244620s per render (631µs), 6.3s total
48.6 times Jinja
28.8 times FastApi

------------------------------------------------------------
CACHE, AUTO-RELOAD: 10_000 renders of realistic case...

JinjaX: 0.000146022997s per render (146µs), 1.5s total
11.2 times Jinja
6.7 times FastApi

------------------------------------------------------------
CACHE, NO AUTO-RELOAD: 10_000 renders of realistic case...

JinjaX: 0.000110918753s per render (111µs), 1.1s total
8.5 times Jinja
5.1 times FastApi
```

As you can see, the difference is measured in **millionths** of one second. Even in the worst case scenario, the difference between JinjaX and Jinja is a little more than _half  a milisecond_ per render, so I'm not sure if this was even worth it...
It's nice to have a benchmark tough.