### PR TITLE
Forward autoescape configuration of `jinja2.Environment` injected into `jinjax.Catalog`

### DIFF
--- a/src/jinjax/catalog.py
+++ b/src/jinjax/catalog.py
@@ -71,6 +71,7 @@ class Catalog:
 
         if jinja_env:
             env.extensions.update(jinja_env.extensions)
+            env.autoescape = jinja_env.autoescape
             globals.update(jinja_env.globals)
             filters.update(jinja_env.filters)
             tests.update(jinja_env.tests)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,6 @@
-import pytest
+import jinja2
 import jinjax
+import pytest
 
 
 @pytest.fixture()
@@ -19,5 +20,13 @@ def folder_t(tmp_path):
 @pytest.fixture()
 def catalog(folder):
     catalog = jinjax.Catalog(auto_reload=False)
+    catalog.add_folder(folder)
+    return catalog
+
+
+@pytest.fixture()
+def autoescaped_catalog(folder):
+    jinja_env = jinja2.Environment(autoescape=True)
+    catalog = jinjax.Catalog(auto_reload=False, jinja_env=jinja_env)
     catalog.add_folder(folder)
     return catalog

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -466,7 +466,7 @@ def test_auto_reload(catalog, folder):
 """.strip() in html3
 
 
-def test_autoescape_doesnot_escape_subcomponents(catalog, folder):
+def test_autoescape_doesnot_escape_subcomponents(autoescaped_catalog, folder):
     """Issue https://github.com/jpsca/jinjax/issues/32"""
     (folder / "Page.jinja").write_text("""
 {#def message #}
@@ -481,8 +481,7 @@ def test_autoescape_doesnot_escape_subcomponents(catalog, folder):
 <p>foo bar</p>
 """)
 
-    catalog.jinja_env.autoescape = True
-    html = catalog.render("Page", message="<3")
+    html = autoescaped_catalog.render("Page", message="<3")
     assert html == """
 <html>
 <p>lorem ipsum</p>


### PR DESCRIPTION
Hi, again, @jpsca :wave:

Currently, if one wants to enable auto-escaping of interpolated variables in JinjaX, one has to mutate the Jinja2 environemnt used by JinjaX like so:

```python
from jinjax import Catalog

catalog = Catalog(...)
catalog.jinja_env.autoescape = True
```

I propose that JinjaX respects the `autoescape` configuration of the passed environment instead, like so:

```python
from jinja2 import Environment
from jinjax import Catalog

jinja_env = Environment(autoescape=True)
catalog = Catalog(jinja_env=jinja_env)
```

Thanks,
- Jakob
