### PR TITLE
Fix bug where remote CSS and JS are not rendered correctly

### DIFF
--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -136,7 +136,7 @@ def test_render_assets(catalog, folder):
 """)
 
     (folder / "Card.jinja").write_text("""
-{#css card.css #}
+{#css https://somewhere.com/style.css, card.css #}
 {#js card.js, shared.js #}
 <section class="card">
 {{ content }}
@@ -165,6 +165,7 @@ def test_render_assets(catalog, folder):
     print(html)
     assert """
 <html>
+<link rel="stylesheet" href="https://somewhere.com/style.css">
 <link rel="stylesheet" href="/static/components/card.css">
 <link rel="stylesheet" href="/static/components/greeting.css">
 <script type="module" src="https://somewhere.com/blabla.js"></script>

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -152,7 +152,7 @@ def test_render_assets(catalog, folder):
 
     (folder / "Page.jinja").write_text("""
 {#def message #}
-{#js shared.js #}
+{#js https://somewhere.com/blabla.js, shared.js #}
 <Layout>
 <Card>
 <Greeting message={message} />
@@ -167,6 +167,7 @@ def test_render_assets(catalog, folder):
 <html>
 <link rel="stylesheet" href="/static/components/card.css">
 <link rel="stylesheet" href="/static/components/greeting.css">
+<script type="module" src="https://somewhere.com/blabla.js"></script>
 <script type="module" src="/static/components/shared.js"></script>
 <script type="module" src="/static/components/card.js"></script>
 <script type="module" src="/static/components/greeting.js"></script>

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -1,12 +1,8 @@
 import time
-
-import pytest
-<<<<<<< HEAD
-import jinja2
-=======
 from pathlib import Path
 
->>>>>>> 281fd27 (Optional fingerprinting)
+import pytest
+import jinja2
 from jinja2.exceptions import TemplateSyntaxError
 
 import jinjax


### PR DESCRIPTION
According to [the docs](https://jinjax.scaletti.dev/guide/css-and-js/) you are allowed to do this:


```
{#js http://example.com/cdn/moment.js, bar.js  #}
```

and at the moment is not working. This PR fixes it.
