### PR TITLE
Add missing space in exception error

### DIFF
--- a/src/jinjax/catalog.py
+++ b/src/jinjax/catalog.py
@@ -236,7 +236,7 @@ class Catalog:
             props[PROP_ATTRS] = HTMLAttrs(extra)
         except Exception as exc:
             raise InvalidArgument(
-                f"The arguments of the component <{component.name}>"
+                f"The arguments of the component <{component.name}> "
                 f"were parsed incorrectly as:\n {str(kw)}"
             ) from exc
 


### PR DESCRIPTION
The exception message for InvalidArgument is missing a space before:
```
        try:
            props[PROP_ATTRS] = HTMLAttrs(extra)
        except Exception as exc:
>           raise InvalidArgument(
                f"The arguments of the component <{component.name}>"
                f"were parsed incorrectly as:\n {str(kw)}"
            ) from exc
E           jinjax.exceptions.InvalidArgument: The arguments of the component <DummyComponent>were parsed incorrectly as:
E            {'widget': Undefined}
```