### PR TITLE
Add support to double-curly-braces syntax in addition of the vue-like syntax for passing arguments to components

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "jinjax"
-version = "0.41"
+version = "0.42"
 description = "Replace your HTML templates with Python server-Side components"
 authors = ["Juan-Pablo Scaletti <juanpablo@jpscaletti.com>"]
 license = "MIT"

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -857,3 +857,45 @@ def test_auto_load_assets_with_same_name(catalog, folder, autoescape):
 """.strip()
 
     assert html == Markup(expected)
+
+
+def test_vue_like_syntax(catalog, folder):
+    (folder / "Test.jinja").write_text("""
+    {#def a, b, c, d #}
+    {{ a }} {{ b }} {{ c }} {{ d }}
+    """)
+    (folder / "Caller.jinja").write_text(
+        """<Test :a="2+2" b="2+2" :c="{'lorem': 'ipsum'}" :d="false" />"""
+    )
+    html = catalog.render("Caller")
+    print(html)
+    expected  = """4 2+2 {'lorem': 'ipsum'} False""".strip()
+    assert html == Markup(expected)
+
+
+def test_jinja_like_syntax(catalog, folder):
+    (folder / "Test.jinja").write_text("""
+    {#def a, b, c, d #}
+    {{ a }} {{ b }} {{ c }} {{ d }}
+    """)
+    (folder / "Caller.jinja").write_text(
+        """<Test a={{ 2+2 }} b="2+2" c={{ {'lorem': 'ipsum'} }} d={{ false }} />"""
+    )
+    html = catalog.render("Caller")
+    print(html)
+    expected  = """4 2+2 {'lorem': 'ipsum'} False""".strip()
+    assert html == Markup(expected)
+
+
+def test_mixed_syntax(catalog, folder):
+    (folder / "Test.jinja").write_text("""
+    {#def a, b, c, d #}
+    {{ a }} {{ b }} {{ c }} {{ d }}
+    """)
+    (folder / "Caller.jinja").write_text(
+        """<Test :a={{ 2+2 }} b="{{2+2}}" :c={{ {'lorem': 'ipsum'} }} :d={{ false }} />"""
+    )
+    html = catalog.render("Caller")
+    print(html)
+    expected  = """4 {{2+2}} {'lorem': 'ipsum'} False""".strip()
+    assert html == Markup(expected)


### PR DESCRIPTION
Both of these are now valid:

```html+jinja
<Example
    columns={{ 2 }}
    tabbed={{ False }}
    panels={{ {'one': 'lorem', 'two': 'ipsum'} }}
    class={{ 'bg-' + color }}
/>

<Example
    :columns="2"
    :tabbed="False"
    :panels="{'one': 'lorem', 'two': 'ipsum'}"
    :class="'bg-' + color"
/>
```