### PR TITLE
Remove dependency that is wrongly imported

### DIFF
--- a/src/jinjax/catalog.py
+++ b/src/jinjax/catalog.py
@@ -12,7 +12,6 @@ from .component import Component
 from .exceptions import ComponentNotFound, InvalidArgument
 from .html_attrs import HTMLAttrs
 from .jinjax import JinjaX
-from .middleware import ComponentsMiddleware
 from .utils import DELIMITER, SLASH, get_url_prefix, logger
 
 


### PR DESCRIPTION
At the moment, the jinjax requires its extra dependency whitenoise because of a wrong top level import