### PR TITLE
chore: officially support Python 3.13

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "Topic :: Internet :: WWW/HTTP :: Dynamic Content",
     "Topic :: Software Development :: Libraries",
     "Topic :: Software Development :: Libraries :: Python Modules",
@@ -95,7 +96,7 @@ addopts = "--doctest-modules"
 legacy_tox_ini = """
 [tox]
 skipsdist = True
-envlist = py310,py311,py312,pypy3.10
+envlist = py310,py311,py312,py313,pypy3.10
 
 [testenv]
 skip_install = true


### PR DESCRIPTION
Adds Python 3.13 as a supported version in the classifiers that appear on PyPI and includes that version in the Tox tests to confirm compatibility.

Everything is passing nicely because Python 3.13 is already in the test workflow, but I thought this couldn't hurt!