### PR TITLE
Fix component syntax for jinjax >=0.41

### DIFF
--- a/docs/components/guide/slots/CompArchive.jinja
+++ b/docs/components/guide/slots/CompArchive.jinja
@@ -3,7 +3,7 @@
 {#def posts #}
 <Layout title="Archive">
   {% for post in posts %}
-    <Post post={post} />
+    <Post :post=post />
   {% endfor %}
 </Layout>
 ```


### PR DESCRIPTION
Found an example with the old syntax while reading the doc.