### PR TITLE
Allow kebab-cased component files

### DIFF
--- a/src/jinjax/utils.py
+++ b/src/jinjax/utils.py
@@ -1,4 +1,5 @@
 import logging
+import re
 import uuid
 
 
@@ -9,9 +10,7 @@ SLASH = "/"
 
 
 def get_url_prefix(prefix: str) -> str:
-    url_prefix = (
-        prefix.strip().strip(f"{DELIMITER}{SLASH}").replace(DELIMITER, SLASH)
-    )
+    url_prefix = prefix.strip().strip(f"{DELIMITER}{SLASH}").replace(DELIMITER, SLASH)
     if url_prefix:
         url_prefix = f"{url_prefix}{SLASH}"
     return url_prefix
@@ -19,3 +18,23 @@ def get_url_prefix(prefix: str) -> str:
 
 def get_random_id(prefix="id") -> str:
     return f"{prefix}-{str(uuid.uuid4().hex)}"
+
+
+def kebab_case(word: str) -> str:
+    """Returns the lowercased kebab-cases form of `word`.
+    Returns the right result even whith acronyms::
+
+        >>> kebab_case("DeviceType")
+        'device-type'
+        >>> kebab_case("IOError")
+        'io-error'
+        >>> kebab_case("HTML")
+        'html'
+        >>> kebab_case("ui.AwesomeDialog")
+        'ui.awesome-dialog'
+
+    """
+    word = re.sub(r"([A-Z]+)([A-Z][a-z])", r"\1-\2", word)
+    word = re.sub(r"([a-z\d])([A-Z])", r"\1-\2", word)
+    word = word.replace("_", "-")
+    return word.lower()

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -1,7 +1,6 @@
 import time
 from pathlib import Path
 from textwrap import dedent
-from threading import Thread
 
 import jinja2
 import pytest
@@ -993,149 +992,13 @@ def test_slots(catalog, folder, autoescape):
     assert html == Markup(expected)
 
 
-class ThreadWithReturnValue(Thread):
-    def __init__(self, group=None, target=None, name=None, args=None, kwargs=None):
-        args = args or ()
-        kwargs = kwargs or {}
-        Thread.__init__(
-            self,
-            group=group,
-            target=target,
-            name=name,
-            args=args,
-            kwargs=kwargs,
-        )
-        self._target = target
-        self._args = args
-        self._kwargs = kwargs
-        self._return = None
+@pytest.mark.parametrize("autoescape", [True, False])
+def test_alt_cased_component_names(catalog, folder, autoescape):
+    (folder / "a_tricky-FOLDER").mkdir()
+    catalog.jinja_env.autoescape = autoescape
 
-    def run(self):
-        if self._target is not None:
-            self._return = self._target(*self._args, **self._kwargs)
+    (folder / "kebab-cased.jinja").write_text("kebab")
+    (folder / "a_tricky-FOLDER" / "Greeting.jinja").write_text("pascal")
 
-    def join(self, *args):
-        Thread.join(self, *args)
-        return self._return
-
-
-def test_thread_safety_of_render_assets(catalog, folder):
-    NUM_THREADS = 5
-
-    child_tmpl = """
-{#css "c{i}.css" #}
-{#js "c{i}.js" #}
-<p>Child {i}</p>""".strip()
-
-    parent_tmpl = """
-{{ catalog.render_assets() }}
-{{ content }}""".strip()
-
-    comp_tmpl = """
-{#css "a{i}.css", "b{i}.css" #}
-{#js "a{i}.js", "b{i}.js" #}
-<Parent{i}><Child{i} /></Parent{i}>""".strip()
-
-    expected_tmpl = """
-<link rel="stylesheet" href="/static/components/a{i}.css">
-<link rel="stylesheet" href="/static/components/b{i}.css">
-<link rel="stylesheet" href="/static/components/c{i}.css">
-<script type="module" src="/static/components/a{i}.js"></script>
-<script type="module" src="/static/components/b{i}.js"></script>
-<script type="module" src="/static/components/c{i}.js"></script>
-<p>Child {i}</p>""".strip()
-
-    def render(i):
-        return catalog.render(f"Page{i}")
-
-
-    for i in range(NUM_THREADS):
-        si = str(i)
-        child_name = f"Child{i}.jinja"
-        child_src = child_tmpl.replace("{i}", si)
-
-        parent_name = f"Parent{i}.jinja"
-        parent_src = parent_tmpl.replace("{i}", si)
-
-        comp_name = f"Page{i}.jinja"
-        comp_src = comp_tmpl.replace("{i}", si)
-
-        (folder / child_name).write_text(child_src)
-        (folder / comp_name).write_text(comp_src)
-        (folder / parent_name).write_text(parent_src)
-
-    threads = []
-
-    for i in range(NUM_THREADS):
-        thread = ThreadWithReturnValue(target=render, args=(i,))
-        threads.append(thread)
-        thread.start()
-
-    results = [thread.join() for thread in threads]
-
-    for i, result in enumerate(results):
-        expected = expected_tmpl.replace("{i}", str(i))
-        print(f"---- EXPECTED {i}----")
-        print(expected)
-        print(f"---- RESULT {i}----")
-        print(result)
-        assert result == Markup(expected)
-
-
-def test_same_thread_assets_independence(catalog, folder):
-    catalog2 = jinjax.Catalog()
-    catalog2.add_folder(folder)
-
-    print(catalog._key)
-    print(catalog2._key)
-
-    (folder / "Parent.jinja").write_text("""
-{{ catalog.render_assets() }}
-{{ content }}""".strip())
-
-    (folder / "Comp1.jinja").write_text("""
-{#css "a.css" #}
-{#js "a.js" #}
-<Parent />""".strip())
-
-    (folder / "Comp2.jinja").write_text("""
-{#css "b.css" #}
-{#js "b.js" #}
-<Parent />""".strip())
-
-    expected_1 = """
-<link rel="stylesheet" href="/static/components/a.css">
-<script type="module" src="/static/components/a.js"></script>""".strip()
-
-    expected_2 = """
-<link rel="stylesheet" href="/static/components/b.css">
-<script type="module" src="/static/components/b.js"></script>""".strip()
-
-    html1 = catalog.render("Comp1")
-    # `irender` instead of `render` so the assets are not cleared
-    html2 = catalog2.irender("Comp2")
-    print(html1)
-    print(html2)
-    assert html1 == Markup(expected_1)
-    assert html2 == Markup(expected_2)
-
-
-def test_thread_safety_of_template_globals(catalog, folder):
-    NUM_THREADS = 5
-    (folder / "Page.jinja").write_text("{{ globalvar if globalvar is defined else 'not set' }}")
-
-    def render(i):
-        return catalog.render("Page", __globals={"globalvar": i})
-
-    threads = []
-
-    for i in range(NUM_THREADS):
-        thread = ThreadWithReturnValue(target=render, args=(i,))
-        threads.append(thread)
-        thread.start()
-
-    results = [thread.join() for thread in threads]
-
-    for i, result in enumerate(results):
-        assert result == Markup(str(i))
-
+    assert catalog.render("KebabCased") == Markup("kebab")
+    assert catalog.render("a_tricky-FOLDER.Greeting") == Markup("pascal")

--- a/tests/test_thread_safety.py
+++ b/tests/test_thread_safety.py
@@ -1,0 +1,153 @@
+from threading import Thread
+
+from markupsafe import Markup
+
+import jinjax
+
+
+class ThreadWithReturnValue(Thread):
+    def __init__(self, group=None, target=None, name=None, args=None, kwargs=None):
+        args = args or ()
+        kwargs = kwargs or {}
+        Thread.__init__(
+            self,
+            group=group,
+            target=target,
+            name=name,
+            args=args,
+            kwargs=kwargs,
+        )
+        self._target = target
+        self._args = args
+        self._kwargs = kwargs
+        self._return = None
+
+    def run(self):
+        if self._target is not None:
+            self._return = self._target(*self._args, **self._kwargs)
+
+    def join(self, *args):
+        Thread.join(self, *args)
+        return self._return
+
+
+def test_thread_safety_of_render_assets(catalog, folder):
+    NUM_THREADS = 5
+
+    child_tmpl = """
+{#css "c{i}.css" #}
+{#js "c{i}.js" #}
+<p>Child {i}</p>""".strip()
+
+    parent_tmpl = """
+{{ catalog.render_assets() }}
+{{ content }}""".strip()
+
+    comp_tmpl = """
+{#css "a{i}.css", "b{i}.css" #}
+{#js "a{i}.js", "b{i}.js" #}
+<Parent{i}><Child{i} /></Parent{i}>""".strip()
+
+    expected_tmpl = """
+<link rel="stylesheet" href="/static/components/a{i}.css">
+<link rel="stylesheet" href="/static/components/b{i}.css">
+<link rel="stylesheet" href="/static/components/c{i}.css">
+<script type="module" src="/static/components/a{i}.js"></script>
+<script type="module" src="/static/components/b{i}.js"></script>
+<script type="module" src="/static/components/c{i}.js"></script>
+<p>Child {i}</p>""".strip()
+
+    def render(i):
+        return catalog.render(f"Page{i}")
+
+
+    for i in range(NUM_THREADS):
+        si = str(i)
+        child_name = f"Child{i}.jinja"
+        child_src = child_tmpl.replace("{i}", si)
+
+        parent_name = f"Parent{i}.jinja"
+        parent_src = parent_tmpl.replace("{i}", si)
+
+        comp_name = f"Page{i}.jinja"
+        comp_src = comp_tmpl.replace("{i}", si)
+
+        (folder / child_name).write_text(child_src)
+        (folder / comp_name).write_text(comp_src)
+        (folder / parent_name).write_text(parent_src)
+
+    threads = []
+
+    for i in range(NUM_THREADS):
+        thread = ThreadWithReturnValue(target=render, args=(i,))
+        threads.append(thread)
+        thread.start()
+
+    results = [thread.join() for thread in threads]
+
+    for i, result in enumerate(results):
+        expected = expected_tmpl.replace("{i}", str(i))
+        print(f"---- EXPECTED {i}----")
+        print(expected)
+        print(f"---- RESULT {i}----")
+        print(result)
+        assert result == Markup(expected)
+
+
+def test_same_thread_assets_independence(catalog, folder):
+    catalog2 = jinjax.Catalog()
+    catalog2.add_folder(folder)
+
+    print(catalog._key)
+    print(catalog2._key)
+
+    (folder / "Parent.jinja").write_text("""
+{{ catalog.render_assets() }}
+{{ content }}""".strip())
+
+    (folder / "Comp1.jinja").write_text("""
+{#css "a.css" #}
+{#js "a.js" #}
+<Parent />""".strip())
+
+    (folder / "Comp2.jinja").write_text("""
+{#css "b.css" #}
+{#js "b.js" #}
+<Parent />""".strip())
+
+    expected_1 = """
+<link rel="stylesheet" href="/static/components/a.css">
+<script type="module" src="/static/components/a.js"></script>""".strip()
+
+    expected_2 = """
+<link rel="stylesheet" href="/static/components/b.css">
+<script type="module" src="/static/components/b.js"></script>""".strip()
+
+    html1 = catalog.render("Comp1")
+    # `irender` instead of `render` so the assets are not cleared
+    html2 = catalog2.irender("Comp2")
+    print(html1)
+    print(html2)
+    assert html1 == Markup(expected_1)
+    assert html2 == Markup(expected_2)
+
+
+def test_thread_safety_of_template_globals(catalog, folder):
+    NUM_THREADS = 5
+    (folder / "Page.jinja").write_text("{{ globalvar if globalvar is defined else 'not set' }}")
+
+    def render(i):
+        return catalog.render("Page", __globals={"globalvar": i})
+
+    threads = []
+
+    for i in range(NUM_THREADS):
+        thread = ThreadWithReturnValue(target=render, args=(i,))
+        threads.append(thread)
+        thread.start()
+
+    results = [thread.join() for thread in threads]
+
+    for i, result in enumerate(results):
+        assert result == Markup(str(i))
+


### PR DESCRIPTION
So the file for `<MyComponent></MyComponent>`  can be named either `MyComponent.jinja` or `my-component.jinja`
