### PR TITLE
Fix critical Windows path error

### DIFF
--- a/src/jinjax/catalog.py
+++ b/src/jinjax/catalog.py
@@ -686,7 +686,7 @@ class Catalog:
             return
         path, relpath = paths
         component = Component(name=name, prefix=prefix, path=path, relpath=relpath)
-        component.tmpl = self.jinja_env.get_template(str(relpath), globals=self.tmpl_globals)
+        component.tmpl = self.jinja_env.get_template(str(relpath.as_posix()), globals=self.tmpl_globals)
         return component
 
     def _split_name(self, cname: str) -> tuple[str, str]:

--- a/src/jinjax/component.py
+++ b/src/jinjax/component.py
@@ -105,11 +105,11 @@ class Component:
             self.load_metadata(source)
 
         if path is not None and relpath is not None:
-            default_css = str(relpath.with_suffix(".css"))
+            default_css = str(relpath.with_suffix(".css").as_posix())
             if (path.with_suffix(".css")).is_file():
                 self.css.extend(self.parse_files_expr(default_css))
 
-            default_js = str(relpath.with_suffix(".js"))
+            default_js = str(relpath.with_suffix(".js").as_posix())
             if (path.with_suffix(".js")).is_file():
                 self.js.extend(self.parse_files_expr(default_js))
 

--- a/src/jinjax/middleware.py
+++ b/src/jinjax/middleware.py
@@ -40,7 +40,7 @@ class ComponentsMiddleware(WhiteNoise):  # type: ignore
             stem = fingerprinted.group(1)
             relpath = relpath.with_name(f"{stem}{ext}")
 
-        return super().find_file(str(relpath))
+        return super().find_file(str(relpath.as_posix()))
 
     def add_file_to_dictionary(
         self, url: str, path: str, stat_cache: t.Any = None


### PR DESCRIPTION
**TLDR**
JinjaX/Jinja errors when using component sub directories or included css/js on Windows due to generic casting of `Pathlib.Path` objects. Fix by casting `Pathlib.Path.as_posix()`.

In `jinjax.catalog`, line 689, casts relpath to str. 
```py
component.tmpl = self.jinja_env.get_template(str(relpath), globals=self.tmpl_globals)
```

`relpath` is a `Pathlib.Path` object, so on Windows, this is a subclass `WindowsPath`.  
An example relpath would be `Path("mySubdir/Component.jinja")`. When cast to str on Windows, this becomes `"mySubdir\\Component.jinja"`.

Jinja expects paths in posix form, with `/` separators, and will error on Windows if `\` is included in the template name string.
`jinja2.loaders`, line 32:
```py
for piece in template.split("/"): # ["mySubdir\\Component.jinja"]
    if (
        os.path.sep in piece # True on Windows, os.path.sep == "\"
        or (os.path.altsep and os.path.altsep in piece)
        or piece == os.path.pardir
    ):
        raise TemplateNotFound(template)
```

This is easily fixed by representing paths as posix paths before casting;
```py
component.tmpl = self.jinja_env.get_template(str(relpath.as_posix()), globals=self.tmpl_globals) # "mySubdir/Component.jinja"

...

for piece in template.split("/"): # ["mySubdir", "Component.jinja"]
    if (
        os.path.sep in piece # False
        or (os.path.altsep and os.path.altsep in piece)
        or piece == os.path.pardir
    ):
        raise TemplateNotFound(template)
```

When running the tests, two other instances of str casting Pathlib.Path were found and fixed for css/js, and middleware.
All tests pass in my Windows environment, posix untested but should be unaffected.