### PR TITLE
Add support for dots in html attribute keys

### DIFF
--- a/src/jinjax/jinjax.py
+++ b/src/jinjax/jinjax.py
@@ -32,7 +32,7 @@ RX_TAG_NAME = re.compile(rf"<(?P<tag>{re_tag_name})(\s|\n|/|>)")
 re_attr_name = r""
 re_equal = r""
 re_attr = r"""
-(?P<name>[a-zA-Z@:$_][a-zA-Z@:$_0-9-]*)
+(?P<name>[a-zA-Z@:$_][a-zA-Z@:$_0-9-.]*)
 (?:
     \s*=\s*
     (?P<value>".*?"|'.*?'|\{\{.*?\}\})

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -653,11 +653,11 @@ def test_alpine_sintax(catalog, folder, autoescape, undefined):
 
     (folder / "Greeting.jinja").write_text("""
 {#def message #}
-<button @click="alert('{{ message }}')">Say Hi</button>""")
+<button @click.prevent="alert('{{ message }}')">Say Hi</button>""")
 
     html = catalog.render("Greeting", message="Hello world!")
     print(html)
-    expected = """<button @click="alert('Hello world!')">Say Hi</button>"""
+    expected = """<button @click.prevent="alert('Hello world!')">Say Hi</button>"""
     assert html == Markup(expected)
 
 
@@ -672,12 +672,12 @@ def test_alpine_sintax_in_component(catalog, folder, autoescape, undefined):
     )
 
     (folder / "Greeting.jinja").write_text(
-        """<Button @click="alert('Hello world!')">Say Hi</Button>"""
+        """<Button @click.prevent="alert('Hello world!')">Say Hi</Button>"""
     )
 
     html = catalog.render("Greeting")
     print(html)
-    expected = """<button @click="alert('Hello world!')">Say Hi</button>"""
+    expected = """<button @click.prevent="alert('Hello world!')">Say Hi</button>"""
     assert html == Markup(expected)
 
 


### PR DESCRIPTION
Building on #60 and issue #57 - HTML attribute keys can also contain dots.

Example from the [alpinejs docs](https://alpinejs.dev/directives/on#prevent)

```html
<form @submit.prevent="console.log('submitted')" action="/foo">
    <button>Submit</button>
</form>
```